### PR TITLE
Update CCTP Lib dependency with static Bzip2 lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,13 +8,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "algebra"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra-derive",
  "byteorder",
  "derivative",
  "field-assembly",
+ "num-bigint",
  "rand",
  "rayon",
  "rustc_version",
@@ -25,7 +26,7 @@ dependencies = [
 [[package]]
 name = "algebra-derive"
 version = "0.2.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -34,14 +35,14 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bench-utils"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 
 [[package]]
 name = "bit-vec"
@@ -96,14 +97,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cctp_primitives"
-version = "0.1.0"
-source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=dev#13f35ee36970927e09c1d5f6780497a25929d172"
+version = "0.1.2"
+source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=pt/bzip2_dependency_static_build#594167539e6cb34d635eef204113dc00a55647bc"
 dependencies = [
  "algebra",
  "bit-vec",
@@ -128,18 +129,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -158,10 +159,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -171,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -224,16 +226,16 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "field-assembly"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "mince",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -252,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -290,8 +292,8 @@ checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "marlin"
-version = "0.2.0"
-source = "git+https://github.com/HorizenLabs/marlin?branch=dev#61daa91696b05f218d9dd5a2c71531dbbd843ceb"
+version = "0.2.2"
+source = "git+https://github.com/HorizenLabs/marlin?branch=dev#1aca34c169da3162e1ba6dd591283ff721d11b5e"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -314,9 +316,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -324,7 +326,7 @@ dependencies = [
 [[package]]
 name = "mince"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "quote",
  "syn",
@@ -350,10 +352,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
+name = "num-bigint"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -367,14 +399,14 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "poly-commit"
-version = "0.2.0"
-source = "git+https://github.com/HorizenLabs/poly-commit?branch=dev#5fde2bdd05cb03cc9340f1621022c4ffd643d441"
+version = "0.2.2"
+source = "git+https://github.com/HorizenLabs/poly-commit?branch=dev#d3e3ac5143a441e2876536382ee1e8f15884bfbe"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -388,14 +420,14 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitives"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -417,8 +449,8 @@ dependencies = [
 
 [[package]]
 name = "proof-systems"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -446,17 +478,19 @@ dependencies = [
 
 [[package]]
 name = "r1cs-core"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
+ "radix_trie",
+ "rand",
  "smallvec",
 ]
 
 [[package]]
 name = "r1cs-crypto"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -470,11 +504,12 @@ dependencies = [
 
 [[package]]
 name = "r1cs-std"
-version = "0.3.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#099baabceec21e7d82327781902b39b2ea7f5c7a"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "derivative",
+ "hex",
  "r1cs-core",
  "radix_trie",
  "rand",
@@ -544,14 +579,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -572,9 +606,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
@@ -627,15 +661,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unroll"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 [[package]]
 name = "cctp_primitives"
 version = "0.1.2"
-source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=pt/bzip2_dependency_static_build#594167539e6cb34d635eef204113dc00a55647bc"
+source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?branch=pt/expose_supported_degree_parameter#7a418e1b8be711c1dd5faa95d6751e637c9ecbb5"
 dependencies = [
  "algebra",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib"]
 [dependencies]
 algebra = { features = ["tweedle"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
 primitives = { features = ["tweedle", "merkle_tree"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
-cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", branch = "pt/bzip2_dependency_static_build" }
+cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", branch = "pt/expose_supported_degree_parameter" }
 proof-systems = { features = ["darlin"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true }
 r1cs-crypto = { features = ["tweedle"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true }
 r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib"]
 [dependencies]
 algebra = { features = ["tweedle"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
 primitives = { features = ["tweedle", "merkle_tree"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
-cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", branch = "dev" }
+cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", branch = "pt/bzip2_dependency_static_build" }
 proof-systems = { features = ["darlin"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true }
 r1cs-crypto = { features = ["tweedle"], git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true }
 r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", optional = true}

--- a/examples/sampleCalls.cpp
+++ b/examples/sampleCalls.cpp
@@ -1567,14 +1567,6 @@ TEST_SUITE("ZendooBatchProofVerifier") {
         CHECK(ret_code == CctpErrorCode::OK);
         zendoo_free_batch_proof_verifier_result(result_5);
 
-        // Check batch verification of all valid proofs fails
-        auto result_6 = batch_verifier.batch_verify_subset_with_segment_size(new_ids, NUM_OF_PROOFS, MAX_SEGMENT_SIZE * 2, &ret_code);
-        CHECK(result_6->result == false);
-        CHECK(result_6->failing_proofs == NULL);
-        CHECK(result_6->failing_proofs_len == 0);
-        CHECK(ret_code == CctpErrorCode::BatchVerifierFailure);
-        zendoo_free_batch_proof_verifier_result(result_6);
-
         // Delete files
         remove((pk_path + std::string("/darlin_csw_test_pk")).c_str());
         remove((vk_path + std::string("/darlin_csw_test_vk")).c_str());

--- a/examples/sampleCalls.cpp
+++ b/examples/sampleCalls.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 #include <time.h>
 
-static const size_t MAX_SEGMENT_SIZE = 1 << 17;
+static const size_t MAX_SEGMENT_SIZE = 1 << 9;
 static bool dlog_keys_init_result([]{ 
     CctpErrorCode ret_code = CctpErrorCode::OK;
 

--- a/examples/sampleCalls.cpp
+++ b/examples/sampleCalls.cpp
@@ -11,6 +11,21 @@
 #include <vector>
 #include <time.h>
 
+static const size_t MAX_SEGMENT_SIZE = 1 << 17;
+static bool dlog_keys_init_result([]{ 
+    CctpErrorCode ret_code = CctpErrorCode::OK;
+
+    // Bootstrap keys
+    bool init_result = zendoo_init_dlog_keys(
+        MAX_SEGMENT_SIZE,
+        &ret_code
+    );
+    assert(init_result == true);
+    assert(ret_code == CctpErrorCode::OK);
+
+    return init_result;
+}());
+
 TEST_SUITE("Field Element") {
 
     TEST_CASE("Field Size") {
@@ -585,19 +600,6 @@ TEST_SUITE("Single Proof Verifier") {
     static std::string params_dir = std::string("../examples");
     static size_t params_dir_len = params_dir.size();
     static const uint32_t NUM_CONSTRAINTS = 1 << 10;
-    static const size_t SEGMENT_SIZE = 1 << 9;
-
-    bool initDlogKeys() {
-        CctpErrorCode ret_code = CctpErrorCode::OK;
-
-        // Bootstrap keys
-        bool init_result = zendoo_init_dlog_keys(
-            SEGMENT_SIZE,
-            &ret_code
-        );
-        CHECK(init_result == true);
-        CHECK(ret_code == CctpErrorCode::OK);
-    }
 
     void create_verify_cert_proof(
         size_t numBt,
@@ -736,9 +738,6 @@ TEST_SUITE("Single Proof Verifier") {
     TEST_CASE("Proof Verifier: Cert - Coboundary Marlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
 
-        // Init keys
-        initDlogKeys();
-
         // Generate cert test circuit pk and vk
         CHECK(
             zendoo_generate_mc_test_params(
@@ -769,9 +768,6 @@ TEST_SUITE("Single Proof Verifier") {
 
     TEST_CASE("Proof Verifier: CertNoConst - Coboundary Marlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
-
-        // Init keys
-        initDlogKeys();
 
         // Generate cert test circuit pk and vk
         CHECK(
@@ -804,9 +800,6 @@ TEST_SUITE("Single Proof Verifier") {
     TEST_CASE("Proof Verifier: Cert - Darlin") {
        CctpErrorCode ret_code = CctpErrorCode::OK;
 
-       // Init keys
-       initDlogKeys();
-
        // Generate cert test circuit pk and vk
        CHECK(
            zendoo_generate_mc_test_params(
@@ -837,9 +830,6 @@ TEST_SUITE("Single Proof Verifier") {
 
     TEST_CASE("Proof Verifier: CertNoConst - Darlin") {
        CctpErrorCode ret_code = CctpErrorCode::OK;
-
-       // Init keys
-       initDlogKeys();
 
        // Generate cert test circuit pk and vk
        CHECK(
@@ -1000,9 +990,6 @@ TEST_SUITE("Single Proof Verifier") {
     TEST_CASE("Proof Verifier: CSW - Coboundary Marlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
 
-        // Init keys
-        initDlogKeys();
-
         // Generate cert test circuit pk and vk
         CHECK(
             zendoo_generate_mc_test_params(
@@ -1033,9 +1020,6 @@ TEST_SUITE("Single Proof Verifier") {
     
     TEST_CASE("Proof Verifier: CSWNoConst - Coboundary Marlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
-
-        // Init keys
-        initDlogKeys();
 
         // Generate cert test circuit pk and vk
         CHECK(
@@ -1068,9 +1052,6 @@ TEST_SUITE("Single Proof Verifier") {
     TEST_CASE("Proof Verifier: CSW - Darlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
 
-        // Init keys
-        initDlogKeys();
-
         // Generate cert test circuit pk and vk
         CHECK(
            zendoo_generate_mc_test_params(
@@ -1101,9 +1082,6 @@ TEST_SUITE("Single Proof Verifier") {
     
     TEST_CASE("Proof Verifier: CSWNoConst - Darlin") {
         CctpErrorCode ret_code = CctpErrorCode::OK;
-
-        // Init keys
-        initDlogKeys();
 
         // Generate cert test circuit pk and vk
         CHECK(
@@ -1139,8 +1117,6 @@ TEST_SUITE("ZendooBatchProofVerifier") {
     static std::string params_dir = std::string("../examples");
     static size_t params_dir_len = params_dir.size();
     static const uint32_t NUM_CONSTRAINTS = 1 << 10;
-    static const size_t MAX_SEGMENT_SIZE = 1 << 17;
-    static const size_t SUPPORTED_SEGMENT_SIZE = 1 << 9;
 
     void add_random_csw_proof(
         ZendooBatchProofVerifier* batch_verifier,
@@ -1330,15 +1306,6 @@ TEST_SUITE("ZendooBatchProofVerifier") {
         static const uint32_t NUM_OF_COMBINATIONS = 8;
 
         CctpErrorCode ret_code = CctpErrorCode::OK;
-
-        // Bootstrap keys used for proving
-        bool init_result = zendoo_init_dlog_keys_test_mode(
-            MAX_SEGMENT_SIZE,
-            SUPPORTED_SEGMENT_SIZE,
-            &ret_code
-        );
-        CHECK(init_result == true);
-
 
         // Generate csw test circuit Darlin pk and vk
         CHECK(
@@ -1538,13 +1505,6 @@ TEST_SUITE("ZendooBatchProofVerifier") {
             }
         }
 
-        bool init_result_2 = zendoo_init_dlog_keys(
-            MAX_SEGMENT_SIZE,
-            &ret_code
-        );
-        CHECK(init_result_2 == true);
-        CHECK(ret_code == CctpErrorCode::OK);
-
         // Batch verify all proofs
         auto result_1 = batch_verifier.batch_verify_all(&ret_code);
         CHECK(result_1->result == true);
@@ -1597,16 +1557,8 @@ TEST_SUITE("ZendooBatchProofVerifier") {
         CHECK(ret_code == CctpErrorCode::OK);
         zendoo_free_batch_proof_verifier_result(result_4);
 
-        bool init_result_3 = zendoo_init_dlog_keys_test_mode(
-            MAX_SEGMENT_SIZE,
-            SUPPORTED_SEGMENT_SIZE/2,
-            &ret_code
-        );
-        CHECK(init_result_3 == true);
-        CHECK(ret_code == CctpErrorCode::OK);
-
         // Check batch verification of all valid proofs fails
-        auto result_5 = batch_verifier.batch_verify_subset(new_ids, NUM_OF_PROOFS, &ret_code);
+        auto result_5 = batch_verifier.batch_verify_subset_with_segment_size(new_ids, NUM_OF_PROOFS, MAX_SEGMENT_SIZE / 2, &ret_code);
         CHECK(result_5->result == false);
         CHECK(result_5->failing_proofs == NULL);
         // Should fail in the hard part due to invalid MSM (scalars > bases),
@@ -1615,26 +1567,12 @@ TEST_SUITE("ZendooBatchProofVerifier") {
         CHECK(ret_code == CctpErrorCode::OK);
         zendoo_free_batch_proof_verifier_result(result_5);
 
-        bool init_result_4 = zendoo_init_dlog_keys_test_mode(
-            MAX_SEGMENT_SIZE * 2,
-            MAX_SEGMENT_SIZE,
-            &ret_code
-        );
-        CHECK(init_result_4 == true);
-        CHECK(ret_code == CctpErrorCode::OK);
-
         // Check batch verification of all valid proofs fails
-        auto result_6 = batch_verifier.batch_verify_subset(new_ids, NUM_OF_PROOFS, &ret_code);
+        auto result_6 = batch_verifier.batch_verify_subset_with_segment_size(new_ids, NUM_OF_PROOFS, MAX_SEGMENT_SIZE * 2, &ret_code);
         CHECK(result_6->result == false);
-        CHECK(result_6->failing_proofs != NULL);
-        CHECK(result_6->failing_proofs_len == NUM_OF_PROOFS);
-        CHECK(ret_code == CctpErrorCode::OK);
-
-        // Hash of the key will differ, so we expect failure in the succinct part,
-        // all proofs will fail, therefore we should get all their indices
-        for(uint32_t i = 0; i < NUM_OF_PROOFS; i++){
-            CHECK(result_6->failing_proofs[i] == i);
-        }
+        CHECK(result_6->failing_proofs == NULL);
+        CHECK(result_6->failing_proofs_len == 0);
+        CHECK(ret_code == CctpErrorCode::BatchVerifierFailure);
         zendoo_free_batch_proof_verifier_result(result_6);
 
         // Delete files

--- a/include/zendoo_mc.h
+++ b/include/zendoo_mc.h
@@ -564,15 +564,6 @@ extern "C" {
         CctpErrorCode* ret_code
     );
 
-    /*
-     * Initialize DLOG keys of specified `supported_segment_size` in memory, derived from keys of size `max_segment_size` .
-     */
-    bool zendoo_init_dlog_keys_test_mode(
-        size_t max_segment_size,
-        size_t supported_segment_size,
-        CctpErrorCode* ret_code
-    );
-
     typedef struct sc_proof sc_proof_t;
 
     /*

--- a/include/zendoo_mc.h
+++ b/include/zendoo_mc.h
@@ -872,7 +872,7 @@ extern "C" {
         const uint32_t* ids_list,
         size_t ids_list_len,
         bool prioritize,
-        size_t segment_size,
+        const size_t* segment_size,
         CctpErrorCode* ret_code
     );
 
@@ -958,7 +958,7 @@ extern "C" {
         }
 
         ZendooBatchProofVerifierResult* batch_verify_subset_with_segment_size(const uint32_t* ids_list, size_t ids_list_len, size_t segment_size, CctpErrorCode* ret_code) {
-            return zendoo_batch_verify_proofs_by_id_with_segment_size(batch_verifier, ids_list, ids_list_len, highPriorityVerification, segment_size, ret_code);
+            return zendoo_batch_verify_proofs_by_id_with_segment_size(batch_verifier, ids_list, ids_list_len, highPriorityVerification, &segment_size, ret_code);
         }
         
         ~ZendooBatchProofVerifier() {

--- a/include/zendoo_mc.h
+++ b/include/zendoo_mc.h
@@ -867,6 +867,15 @@ extern "C" {
         CctpErrorCode* ret_code
     );
 
+    ZendooBatchProofVerifierResult* zendoo_batch_verify_proofs_by_id_with_segment_size(
+        const sc_batch_proof_verifier_t* batch_verifier,
+        const uint32_t* ids_list,
+        size_t ids_list_len,
+        bool prioritize,
+        size_t segment_size,
+        CctpErrorCode* ret_code
+    );
+
     /*
      * Free the memory pointed by `batch_verifier`,
     */
@@ -946,6 +955,10 @@ extern "C" {
 
         ZendooBatchProofVerifierResult* batch_verify_subset(const uint32_t* ids_list, size_t ids_list_len, CctpErrorCode* ret_code) {
             return zendoo_batch_verify_proofs_by_id(batch_verifier, ids_list, ids_list_len, highPriorityVerification, ret_code);
+        }
+
+        ZendooBatchProofVerifierResult* batch_verify_subset_with_segment_size(const uint32_t* ids_list, size_t ids_list_len, size_t segment_size, CctpErrorCode* ret_code) {
+            return zendoo_batch_verify_proofs_by_id_with_segment_size(batch_verifier, ids_list, ids_list_len, highPriorityVerification, segment_size, ret_code);
         }
         
         ~ZendooBatchProofVerifier() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,15 +575,6 @@ pub extern "C" fn zendoo_init_dlog_keys(segment_size: usize, ret_code: &mut Cctp
 }
 
 #[no_mangle]
-pub extern "C" fn zendoo_init_dlog_keys_test_mode(
-    max_segment_size: usize,
-    ret_code: &mut CctpErrorCode,
-) -> bool {
-    // Get DLOG keys
-    _zendoo_init_dlog_keys(max_segment_size, ret_code)
-}
-
-#[no_mangle]
 pub extern "C" fn zendoo_serialize_sc_proof(
     sc_proof: *const ZendooProof,
     ret_code: &mut CctpErrorCode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1465,6 +1465,84 @@ pub extern "C" fn zendoo_batch_verify_proofs_by_id(
     Box::into_raw(Box::new(ret))
 }
 
+/**
+ * This function is basically a clone of zendoo_batch_verify_proofs_by_id(),
+ * the only difference is the call to batch_verify_subset_with_segment_size()
+ * instead of batch_verify_subset().
+ * It is used for testing purpose only.
+ */
+#[no_mangle]
+pub extern "C" fn zendoo_batch_verify_proofs_by_id_with_segment_size(
+    batch_verifier: *const ZendooBatchVerifier,
+    ids_list: *const u32,
+    ids_list_len: usize,
+    prioritize: bool,
+    segment_size: usize,
+    ret_code: &mut CctpErrorCode,
+) -> *mut ZendooBatchProofVerifierResult {
+    // Read batch verifier
+    let rs_batch_verifier =
+        try_read_raw_pointer!("batch_verifier", batch_verifier, ret_code, null_mut());
+
+    // Get ids_list
+    let rs_ids_list = try_get_obj_list!("ids_list", ids_list, ids_list_len, ret_code, null_mut());
+
+    // If prioritize, pause all low priority threads
+    if prioritize {
+        zendoo_pause_low_priority_threads();
+    }
+
+    // Execute batch verification of the proofs with specified id
+    let result = match get_batch_verifier_thread_pool(prioritize) {
+        Ok(pool) => pool.install(|| {
+            rs_batch_verifier.batch_verify_subset_with_segment_size(rs_ids_list.to_vec(), &mut OsRng::default(), Some(segment_size))
+        }),
+        Err(e) => {
+            eprintln!("{:?}", e);
+            *ret_code = CctpErrorCode::GenericError;
+            return null_mut();
+        }
+    };
+
+    // If prioritize, Unpause all low priority threads
+    if prioritize {
+        zendoo_unpause_low_priority_threads();
+    }
+
+    let mut ret = ZendooBatchProofVerifierResult::default();
+
+    // Trigger batch verification of the proofs with specified id
+    match result {
+        // If success, return the result
+        Ok(result) => {
+            ret.result = result;
+        }
+
+        // Otherwise, return the indices of the failing proofs if it's possible to estabilish it.
+        Err(e) => {
+            eprintln!("{:?}", format!("Batch proof verification failure: {:?}", e));
+            match e {
+                ProvingSystemError::FailedBatchVerification(maybe_ids) => {
+                    *ret_code = CctpErrorCode::OK;
+                    if maybe_ids.is_some() {
+                        // Return ids
+                        let mut ids = maybe_ids.unwrap();
+                        ids.shrink_to_fit();
+                        let len = ids.len();
+                        assert_eq!(len, ids.capacity());
+                        let ids_ptr = ids.as_mut_ptr();
+                        ret.failing_proofs = ids_ptr;
+                        ret.num_failing_proofs = len;
+                        std::mem::forget(ids);
+                    }
+                }
+                _ => *ret_code = CctpErrorCode::BatchVerifierFailure,
+            }
+        }
+    }
+    Box::into_raw(Box::new(ret))
+}
+
 #[no_mangle]
 pub extern "C" fn zendoo_free_batch_proof_verifier(batch_verifier: *mut ZendooBatchVerifier) {
     free_pointer(batch_verifier)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,6 @@ pub extern "C" fn zendoo_print_field(field: *const FieldElement) {
 
 fn _zendoo_init_dlog_keys(
     max_segment_size: usize,
-    supported_segment_size: usize,
     ret_code: &mut CctpErrorCode,
 ) -> bool {
     *ret_code = CctpErrorCode::OK;
@@ -544,7 +543,6 @@ fn _zendoo_init_dlog_keys(
     match init_dlog_keys(
         ProvingSystem::Darlin,
         max_segment_size,
-        supported_segment_size,
     ) {
         Ok(()) => true,
         Err(e) => {
@@ -573,17 +571,16 @@ pub extern "C" fn zendoo_get_proving_system_type(
 #[no_mangle]
 pub extern "C" fn zendoo_init_dlog_keys(segment_size: usize, ret_code: &mut CctpErrorCode) -> bool {
     // Get DLOG keys
-    _zendoo_init_dlog_keys(segment_size, segment_size, ret_code)
+    _zendoo_init_dlog_keys(segment_size, ret_code)
 }
 
 #[no_mangle]
 pub extern "C" fn zendoo_init_dlog_keys_test_mode(
     max_segment_size: usize,
-    supported_segment_size: usize,
     ret_code: &mut CctpErrorCode,
 ) -> bool {
     // Get DLOG keys
-    _zendoo_init_dlog_keys(max_segment_size, supported_segment_size, ret_code)
+    _zendoo_init_dlog_keys(max_segment_size, ret_code)
 }
 
 #[no_mangle]

--- a/src/mc_test_circuits/cert.rs
+++ b/src/mc_test_circuits/cert.rs
@@ -10,7 +10,7 @@ use cctp_primitives::{
     utils::{data_structures::BackwardTransfer, get_cert_data_hash},
 };
 use proof_systems::darlin::data_structures::{FinalDarlinDeferredData, FinalDarlinProof};
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, ConstraintSystemAbstract, SynthesisError};
 use r1cs_std::{
     alloc::AllocGadget, bits::boolean::Boolean, eq::EqGadget, instantiated::tweedle::FrGadget,
 };
@@ -18,7 +18,7 @@ use rand::rngs::OsRng;
 
 type FieldElementGadget = FrGadget;
 
-fn enforce_cert_inputs_gadget<CS: ConstraintSystem<FieldElement>>(
+fn enforce_cert_inputs_gadget<CS: ConstraintSystemAbstract<FieldElement>>(
     mut cs: CS,
     constant_present: bool,
     constant: Option<FieldElement>,
@@ -86,7 +86,7 @@ pub struct CertTestCircuit {
 }
 
 impl ConstraintSynthesizer<FieldElement> for CertTestCircuit {
-    fn generate_constraints<CS: ConstraintSystem<FieldElement>>(
+    fn generate_constraints<CS: ConstraintSystemAbstract<FieldElement>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -111,7 +111,7 @@ pub struct CertTestCircuitWithAccumulators {
 }
 
 impl ConstraintSynthesizer<FieldElement> for CertTestCircuitWithAccumulators {
-    fn generate_constraints<CS: ConstraintSystem<FieldElement>>(
+    fn generate_constraints<CS: ConstraintSystemAbstract<FieldElement>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -172,25 +172,25 @@ pub fn generate_parameters(
     num_constraints: u32,
     with_constant: bool,
 ) -> Result<(ZendooProverKey, ZendooVerifierKey), ProvingSystemError> {
-    let ck_g1 = get_g1_committer_key()?;
+    let ck_g1 = get_g1_committer_key(None)?;
     match ps {
         ProvingSystem::Undefined => Err(ProvingSystemError::UndefinedProvingSystem),
         ProvingSystem::Darlin => {
-            let ck_g2 = get_g2_committer_key()?;
+            let ck_g2 = get_g2_committer_key(None)?;
             let circ = CertTestCircuitWithAccumulators {
                 constant_present: with_constant,
                 constant: None,
                 cert_data_hash: None,
                 deferred: FinalDarlinDeferredData::<G1, G2>::generate_random::<_, Digest>(
                     &mut rand::thread_rng(),
-                    ck_g1.as_ref().unwrap(),
-                    ck_g2.as_ref().unwrap(),
+                    &ck_g1,
+                    &ck_g2,
                 )
                 .to_field_elements()
                 .unwrap(),
                 num_constraints,
             };
-            let (pk, vk) = CoboundaryMarlin::index(ck_g1.as_ref().unwrap(), circ)
+            let (pk, vk) = CoboundaryMarlin::index(&ck_g1, circ)
                 .map_err(|e| ProvingSystemError::SetupFailed(e.to_string()))?;
             Ok((ZendooProverKey::Darlin(pk), ZendooVerifierKey::Darlin(vk)))
         }
@@ -201,7 +201,7 @@ pub fn generate_parameters(
                 cert_data_hash: None,
                 num_constraints,
             };
-            let (pk, vk) = CoboundaryMarlin::index(ck_g1.as_ref().unwrap(), circ)
+            let (pk, vk) = CoboundaryMarlin::index(&ck_g1, circ)
                 .map_err(|e| ProvingSystemError::SetupFailed(e.to_string()))?;
             Ok((
                 ZendooProverKey::CoboundaryMarlin(pk),
@@ -226,7 +226,7 @@ pub fn generate_proof(
     num_constraints: u32,
 ) -> Result<ZendooProof, ProvingSystemError> {
     let rng = &mut OsRng;
-    let ck_g1 = get_g1_committer_key()?;
+    let ck_g1 = get_g1_committer_key(None)?;
 
     // Read input param into field elements
     let cert_data_hash = get_cert_data_hash(
@@ -243,11 +243,11 @@ pub fn generate_proof(
 
     match pk {
         ZendooProverKey::Darlin(pk) => {
-            let ck_g2 = get_g2_committer_key()?;
+            let ck_g2 = get_g2_committer_key(None)?;
             let deferred = FinalDarlinDeferredData::<G1, G2>::generate_random::<_, Digest>(
                 rng,
-                ck_g1.as_ref().unwrap(),
-                ck_g2.as_ref().unwrap(),
+                &ck_g1,
+                &ck_g2,
             );
             let deferred_fes = deferred.to_field_elements().unwrap();
             let circ = CertTestCircuitWithAccumulators {
@@ -263,7 +263,7 @@ pub fn generate_proof(
             };
             let proof = CoboundaryMarlin::prove(
                 pk,
-                ck_g1.as_ref().unwrap(),
+                &ck_g1,
                 circ,
                 zk,
                 if zk { Some(rng) } else { None },
@@ -288,7 +288,7 @@ pub fn generate_proof(
             };
             let proof = CoboundaryMarlin::prove(
                 pk,
-                ck_g1.as_ref().unwrap(),
+                &ck_g1,
                 circ,
                 zk,
                 if zk { Some(rng) } else { None },

--- a/src/mc_test_circuits/csw.rs
+++ b/src/mc_test_circuits/csw.rs
@@ -7,10 +7,10 @@ use cctp_primitives::{
         ProvingSystem, ZendooProof, ZendooProverKey, ZendooVerifierKey,
     },
     type_mapping::FieldElement,
-    utils::commitment_tree::{hash_vec, ByteAccumulator},
+    utils::commitment_tree::{hash_vec, DataAccumulator},
 };
 use proof_systems::darlin::data_structures::{FinalDarlinDeferredData, FinalDarlinProof};
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, ConstraintSystemAbstract, SynthesisError};
 use r1cs_std::{
     alloc::AllocGadget, bits::boolean::Boolean, eq::EqGadget, instantiated::tweedle::FrGadget,
 };
@@ -18,7 +18,7 @@ use rand::rngs::OsRng;
 
 type FieldElementGadget = FrGadget;
 
-fn enforce_csw_inputs_gadget<CS: ConstraintSystem<FieldElement>>(
+fn enforce_csw_inputs_gadget<CS: ConstraintSystemAbstract<FieldElement>>(
     mut cs: CS,
     constant_present: bool,
     constant: Option<FieldElement>,
@@ -85,7 +85,7 @@ pub struct CSWTestCircuit {
 }
 
 impl ConstraintSynthesizer<FieldElement> for CSWTestCircuit {
-    fn generate_constraints<CS: ConstraintSystem<FieldElement>>(
+    fn generate_constraints<CS: ConstraintSystemAbstract<FieldElement>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -110,7 +110,7 @@ pub struct CSWTestCircuitWithAccumulators {
 }
 
 impl ConstraintSynthesizer<FieldElement> for CSWTestCircuitWithAccumulators {
-    fn generate_constraints<CS: ConstraintSystem<FieldElement>>(
+    fn generate_constraints<CS: ConstraintSystemAbstract<FieldElement>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -168,25 +168,25 @@ pub fn generate_parameters(
     num_constraints: u32,
     with_constant: bool,
 ) -> Result<(ZendooProverKey, ZendooVerifierKey), ProvingSystemError> {
-    let ck_g1 = get_g1_committer_key()?;
+    let ck_g1 = get_g1_committer_key(None)?;
     match ps {
         ProvingSystem::Undefined => Err(ProvingSystemError::UndefinedProvingSystem),
         ProvingSystem::Darlin => {
-            let ck_g2 = get_g2_committer_key()?;
+            let ck_g2 = get_g2_committer_key(None)?;
             let circ = CSWTestCircuitWithAccumulators {
                 constant_present: with_constant,
                 constant: None,
                 aggregated_input: None,
                 deferred: FinalDarlinDeferredData::<G1, G2>::generate_random::<_, Digest>(
                     &mut rand::thread_rng(),
-                    ck_g1.as_ref().unwrap(),
-                    ck_g2.as_ref().unwrap(),
+                    &ck_g1,
+                    &ck_g2,
                 )
                 .to_field_elements()
                 .unwrap(),
                 num_constraints,
             };
-            let (pk, vk) = CoboundaryMarlin::index(ck_g1.as_ref().unwrap(), circ)
+            let (pk, vk) = CoboundaryMarlin::index(&ck_g1, circ)
                 .map_err(|e| ProvingSystemError::SetupFailed(e.to_string()))?;
             Ok((ZendooProverKey::Darlin(pk), ZendooVerifierKey::Darlin(vk)))
         }
@@ -197,7 +197,7 @@ pub fn generate_parameters(
                 aggregated_input: None,
                 num_constraints,
             };
-            let (pk, vk) = CoboundaryMarlin::index(ck_g1.as_ref().unwrap(), circ)
+            let (pk, vk) = CoboundaryMarlin::index(&ck_g1, circ)
                 .map_err(|e| ProvingSystemError::SetupFailed(e.to_string()))?;
             Ok((
                 ZendooProverKey::CoboundaryMarlin(pk),
@@ -220,9 +220,9 @@ pub fn generate_proof(
     num_constraints: u32,
 ) -> Result<ZendooProof, ProvingSystemError> {
     let rng = &mut OsRng;
-    let ck_g1 = get_g1_committer_key()?;
+    let ck_g1 = get_g1_committer_key(None)?;
 
-    let mut fes = ByteAccumulator::init()
+    let mut fes = DataAccumulator::init()
         .update(amount)
         .map_err(|e| ProvingSystemError::Other(format!("{:?}", e)))?
         .update(&pub_key_hash[..])
@@ -242,11 +242,11 @@ pub fn generate_proof(
 
     match pk {
         ZendooProverKey::Darlin(pk) => {
-            let ck_g2 = get_g2_committer_key()?;
+            let ck_g2 = get_g2_committer_key(None)?;
             let deferred = FinalDarlinDeferredData::<G1, G2>::generate_random::<_, Digest>(
                 rng,
-                ck_g1.as_ref().unwrap(),
-                ck_g2.as_ref().unwrap(),
+                &ck_g1,
+                &ck_g2,
             );
             let deferred_fes = deferred.to_field_elements().unwrap();
             let circ = CSWTestCircuitWithAccumulators {
@@ -262,7 +262,7 @@ pub fn generate_proof(
             };
             let proof = CoboundaryMarlin::prove(
                 pk,
-                ck_g1.as_ref().unwrap(),
+                &ck_g1,
                 circ,
                 zk,
                 if zk { Some(rng) } else { None },
@@ -287,7 +287,7 @@ pub fn generate_proof(
             };
             let proof = CoboundaryMarlin::prove(
                 pk,
-                ck_g1.as_ref().unwrap(),
+                &ck_g1,
                 circ,
                 zk,
                 if zk { Some(rng) } else { None },


### PR DESCRIPTION
This PR updates the CCTP Lib dependency to the latest version, that includes a small fix to statically link the Bzip2 library.
Such change is required to avoid errors when compiling Zend on systems on which Bzip2 is installed as shared library, since in that case Cargo uses the dynamic linking without providing the Bzip2 symbols.

Such update required also some small changes to make unit tests compatible with the new CCTP Lib.