### PR TITLE
Add rust-side logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 examples/bin_SampleCalls
 mc_test/mcTest
 mc_test/*.o
+/*.log
 
 # Intellij
 .idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,13 +10,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "algebra"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra-derive",
  "byteorder",
  "derivative",
  "field-assembly",
+ "log",
  "num-bigint",
  "rand",
  "rayon",
@@ -27,8 +28,8 @@ dependencies = [
 
 [[package]]
 name = "algebra-derive"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -70,8 +71,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bench-utils"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 
 [[package]]
 name = "bit-vec"
@@ -147,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "cctp_primitives"
-version = "0.2.1"
-source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?tag=0.2.1#447813da7842db937df3e2d7f2d3eb83675883ff"
+version = "0.2.2"
+source = "git+https://github.com/HorizenOfficial/zendoo-cctp-lib.git?tag=0.2.2#42d98fe6e65777fbb20316a6f7d85c7c1c7a47fb"
 dependencies = [
  "algebra",
  "bit-vec",
@@ -157,6 +158,7 @@ dependencies = [
  "bzip2",
  "flate2",
  "lazy_static",
+ "log",
  "marlin",
  "poly-commit",
  "primitives",
@@ -283,9 +285,10 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "field-assembly"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
+ "log",
  "quote",
  "syn 1.0.109",
 ]
@@ -464,13 +467,14 @@ dependencies = [
 
 [[package]]
 name = "marlin"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "bench-utils",
  "derivative",
  "digest",
+ "log",
  "poly-commit",
  "r1cs-core",
  "r1cs-std",
@@ -596,13 +600,14 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "poly-commit"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "bench-utils",
  "derivative",
  "digest",
+ "log",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -618,13 +623,14 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitives"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "bench-utils",
  "derivative",
  "hex",
+ "log",
  "num-bigint",
  "rand",
  "rayon",
@@ -643,14 +649,15 @@ dependencies = [
 
 [[package]]
 name = "proof-systems"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "bench-utils",
  "byteorder",
  "derivative",
  "digest",
+ "log",
  "marlin",
  "poly-commit",
  "r1cs-core",
@@ -673,8 +680,8 @@ dependencies = [
 
 [[package]]
 name = "r1cs-core"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "radix_trie",
@@ -684,12 +691,13 @@ dependencies = [
 
 [[package]]
 name = "r1cs-crypto"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "bench-utils",
  "derivative",
+ "log",
  "primitives",
  "r1cs-core",
  "r1cs-std",
@@ -700,12 +708,13 @@ dependencies = [
 
 [[package]]
 name = "r1cs-std"
-version = "0.6.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
+version = "0.6.1"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
 dependencies = [
  "algebra",
  "derivative",
  "hex",
+ "log",
  "r1cs-core",
  "radix_trie",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "blake2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +96,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-tools"
@@ -128,6 +167,26 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -204,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +358,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,9 +419,67 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derivative",
+ "flate2",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "thread-id",
+ "typemap-ors",
+ "winapi",
+]
 
 [[package]]
 name = "marlin"
@@ -386,10 +575,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pkg-config"
@@ -437,11 +664,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -467,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -590,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +833,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
@@ -620,6 +862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +880,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -660,10 +935,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "typemap-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
+dependencies = [
+ "unsafe-any-ors",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-xid"
@@ -682,10 +1002,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-any-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
+dependencies = [
+ "destructure_traitobject",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"
@@ -710,6 +1093,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "zendoo-mc-crypto"
 version = "0.4.0"
 dependencies = [
@@ -719,6 +1177,8 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "libc",
+ "log",
+ "log4rs",
  "maybe-uninit",
  "primitives",
  "proof-systems",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -111,9 +111,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bzip2"
@@ -138,9 +138,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cctp_primitives"
@@ -198,16 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,12 +226,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -259,7 +251,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -279,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "endian-type"
@@ -295,18 +287,16 @@ version = "0.6.0"
 source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.0#46a3ce6d7b6f1937bb4e8b81ef8052ac60271142"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -327,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -341,15 +331,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -404,9 +385,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -517,12 +498,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -536,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -557,21 +537,11 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -753,14 +723,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -775,45 +744,31 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]
@@ -842,21 +797,21 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -873,20 +828,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -907,15 +862,24 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "subtle"
@@ -925,33 +889,44 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -975,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -986,19 +961,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unroll"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1012,15 +981,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1028,24 +997,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1053,22 +1022,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "algebra"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra-derive",
  "byteorder",
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "algebra-derive"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -72,7 +72,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "bench-utils"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 
 [[package]]
 name = "bit-vec"
@@ -286,7 +286,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "field-assembly"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "log",
  "quote",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "marlin"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -601,7 +601,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 [[package]]
 name = "poly-commit"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -624,7 +624,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primitives"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "proof-systems"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "radix_trie",
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "r1cs-crypto"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.6.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#274973dd761a674870503c7710cc27c82e0a6039"
+source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.6.1#35cd278f24f70b498095190e360754b2c13cc4b8"
 dependencies = [
  "algebra",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "zendoo-mc-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "algebra",
  "cctp_primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,18 +76,14 @@ debug = true
 
 # Uncomment these lines for local development paths
 #
-#[patch.'https://github.com/HorizenOfficial/ginger-lib.git']
-#algebra = { path = '../ginger-lib/algebra' }
-#primitives = { path = '../ginger-lib/primitives' }
-#r1cs-core = { path = '../ginger-lib/r1cs/core' }
-#r1cs-crypto = { path = '../ginger-lib/r1cs/gadgets/crypto' }
-#r1cs-std = { path = '../ginger-lib/r1cs/gadgets/std' }
-#
-#[patch.'https://github.com/HorizenOfficial/zendoo-cctp-lib.git']
-#cctp_primitives = { path = '../zendoo-cctp-lib/cctp_primitives' }
-#
-#[patch.'https://github.com/HorizenLabs/marlin']
-#marlin = { path = '../marlin' }
-#
-#[patch.'https://github.com/HorizenLabs/poly-commit']
-#poly-commit = { path = '../poly-commit' }
+# [patch.'https://github.com/HorizenOfficial/ginger-lib.git']
+# algebra = { path = '../ginger-lib/algebra' }
+# primitives = { path = '../ginger-lib/primitives' }
+# r1cs-core = { path = '../ginger-lib/r1cs/core' }
+# r1cs-crypto = { path = '../ginger-lib/r1cs/gadgets/crypto' }
+# r1cs-std = { path = '../ginger-lib/r1cs/gadgets/std' }
+# marlin = { path = '../ginger-lib/proof-systems/src/marlin' }
+# poly-commit = { path = '../ginger-lib/proof-systems/src/poly-commit' }
+
+# [patch.'https://github.com/HorizenOfficial/zendoo-cctp-lib.git']
+# cctp_primitives = { path = '../zendoo-cctp-lib/cctp_primitives' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ debug = true
 # [patch.'https://github.com/HorizenOfficial/ginger-lib.git']
 # algebra = { path = '../ginger-lib/algebra' }
 # primitives = { path = '../ginger-lib/primitives' }
+# proof-systems = { path = "../ginger-lib/proof-systems"}
 # r1cs-core = { path = '../ginger-lib/r1cs/core' }
 # r1cs-crypto = { path = '../ginger-lib/r1cs/gadgets/crypto' }
 # r1cs-std = { path = '../ginger-lib/r1cs/gadgets/std' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,22 @@ crate-type = ["staticlib"]
 [dependencies]
 algebra = { features = [
     "tweedle",
-], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0" }
+], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1" }
 primitives = { features = [
     "tweedle",
     "merkle_tree",
-], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0" }
-cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", tag = "0.2.1" }
+], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1" }
+cctp_primitives = { git = "https://github.com/HorizenOfficial/zendoo-cctp-lib.git", tag = "0.2.2" }
 proof-systems = { features = [
     "darlin",
-], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0", optional = true }
+], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1", optional = true }
 r1cs-crypto = { features = [
     "tweedle",
-], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0", optional = true }
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0", optional = true }
+], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1", optional = true }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1", optional = true }
 r1cs-std = { features = [
     "tweedle",
-], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.0", optional = true }
+], git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.6.1", optional = true }
 crossbeam-utils = "0.8.7"
 maybe-uninit = "2.0.0"
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendoo-mc-crypto"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "DanieleDiBenedetto <daniele@horizenlabs.io>",
     "Maksym Vereshchak <phoinic@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ lazy_static = "1.4.0"
 libc = "0.2.97"
 cfg-if = "1.0.0"
 rayon = { version = "1" }
+log4rs = { version = "1.2.0", features = ["gzip", "config_parsing"] }
+log = { version = "0.4.0", features = ["std"] }
 
 [features]
 default = ["parallel", "asm"]

--- a/examples/sampleCalls.cpp
+++ b/examples/sampleCalls.cpp
@@ -12,6 +12,7 @@
 #include <time.h>
 
 static const uint32_t MAX_SEGMENT_SIZE = 1 << 9;
+
 static bool dlog_keys_init_result([]{ 
     CctpErrorCode ret_code = CctpErrorCode::OK;
 
@@ -24,6 +25,19 @@ static bool dlog_keys_init_result([]{
     assert(ret_code == CctpErrorCode::OK);
 
     return init_result;
+}());
+
+static bool init_zendoo([]{
+    CctpErrorCode ret_code = CctpErrorCode::OK;
+
+    const char* log_config_path = "../src/tests/log/sample_log_config.yaml";
+    zendoo_init(
+        (path_char_t const*) log_config_path,
+        strlen(log_config_path),
+        &ret_code
+    );
+    assert(ret_code == CctpErrorCode::OK);
+    return true;
 }());
 
 TEST_SUITE("Field Element") {

--- a/include/hex_utils.h
+++ b/include/hex_utils.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 using namespace std;
 

--- a/include/zendoo_mc.h
+++ b/include/zendoo_mc.h
@@ -7,40 +7,55 @@
 static const size_t FIELD_SIZE = 32;
 static const size_t MC_PK_SIZE = 20;
 
-extern "C" {
+extern "C"
+{
 
-    #ifdef WIN32
-        typedef uint16_t path_char_t;
-    #else
-        typedef uint8_t path_char_t;
-    #endif
+#ifdef WIN32
+    typedef uint16_t path_char_t;
+#else
+    typedef uint8_t path_char_t;
+#endif
 
-    typedef struct backward_transfer{
+    typedef struct backward_transfer
+    {
         unsigned char pk_dest[20];
         uint64_t amount;
     } backward_transfer_t;
 
-    typedef enum eCctpErrorCode {
-            OK,
-            NullPtr,
-            InvalidValue,
-            InvalidBufferData,
-            InvalidBufferLength,
-            InvalidListLength,
-            InvalidFile,
-            HashingError,
-            MerkleTreeError,
-            ProofVerificationFailure,
-            BatchVerifierFailure,
-            FailedBatchProofVerification,
-            CompressError,
-            UncompressError,
-            MerkleRootBuildError,
-            GenericError,
-            TestProofCreationFailure,
+    typedef enum eCctpErrorCode
+    {
+        OK,
+        NullPtr,
+        InvalidValue,
+        InvalidBufferData,
+        InvalidBufferLength,
+        InvalidListLength,
+        InvalidFile,
+        HashingError,
+        MerkleTreeError,
+        ProofVerificationFailure,
+        BatchVerifierFailure,
+        FailedBatchProofVerification,
+        CompressError,
+        UncompressError,
+        MerkleRootBuildError,
+        GenericError,
+        TestProofCreationFailure,
+        InitializationError,
     } CctpErrorCode;
 
-    //Field related functions
+    /*
+     * Initialize Rust library. In particular:
+     *  - Initializes a logger Rust-side using as config the one supplied at `config_path_len`.
+     * Set `ret_code` to Ok if initialization was successfull, `InitializationError` otherwise.
+     * This function is supposed to be called only once.
+     */
+    void zendoo_init(
+        const path_char_t *config_path,
+        size_t config_path_len,
+        CctpErrorCode *ret_code);
+
+    // Field related functions
     /* Note: Functions panic if input pointers are NULL.*/
 
     typedef struct field field_t;
@@ -55,56 +70,57 @@ extern "C" {
      * Return true if the operation was successfull, false otherwise.
      */
     bool zendoo_serialize_field(
-        const field_t*  field,
-        unsigned char*  field_bytes,
-        CctpErrorCode*  ret_code
-    );
+        const field_t *field,
+        unsigned char *field_bytes,
+        CctpErrorCode *ret_code);
 
     /*
      * Deserialize a field from `field_bytes` and return an opaque pointer to it.
      * It's caller's responsibility to ensure that `field_bytes` size is equal to the one
      * returned by `zendoo_get_field_size_in_bytes`. Return NULL if deserialization fails.
      */
-    field_t* zendoo_deserialize_field(const unsigned char* field_bytes, CctpErrorCode* ret_code);
+    field_t *zendoo_deserialize_field(const unsigned char *field_bytes, CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the field pointed by `field`. It's caller responsibility
      * to set `field` to NULL afterwards. If `field` was already null, the function does
      * nothing.
      */
-    void zendoo_field_free(field_t* field);
+    void zendoo_field_free(field_t *field);
 
     /*
      * Print field bytes
      */
-    void zendoo_print_field(field_t* field);
+    void zendoo_print_field(field_t *field);
 
-    struct BufferWithSize {
-        const unsigned char* data;
+    struct BufferWithSize
+    {
+        const unsigned char *data;
         size_t len;
 
-        BufferWithSize(): data(NULL), len(0) {}
-        BufferWithSize(const unsigned char* dataIn, size_t lenIn): data(dataIn), len(lenIn) {}
+        BufferWithSize() : data(NULL), len(0) {}
+        BufferWithSize(const unsigned char *dataIn, size_t lenIn) : data(dataIn), len(lenIn) {}
     };
 
     /* Free a BufferWithSize allocated Rust-side */
-    void zendoo_free_bws(BufferWithSize* buf);
+    void zendoo_free_bws(BufferWithSize *buf);
 
     // Commitment Tree related declarations
 
-    typedef enum class ProvingSystem {
+    typedef enum class ProvingSystem
+    {
         Undefined,
         Darlin,
         CoboundaryMarlin
     } ProvingSystem;
 
-    struct BitVectorElementsConfig {
+    struct BitVectorElementsConfig
+    {
         uint32_t bit_vector_size_bits;
         uint32_t max_compressed_byte_size;
 
-        BitVectorElementsConfig(): bit_vector_size_bits(0), max_compressed_byte_size(0) {}
-        BitVectorElementsConfig(uint32_t bit_vector_size_bits, uint32_t max_compressed_byte_size):
-            bit_vector_size_bits(bit_vector_size_bits), max_compressed_byte_size(max_compressed_byte_size) {}
+        BitVectorElementsConfig() : bit_vector_size_bits(0), max_compressed_byte_size(0) {}
+        BitVectorElementsConfig(uint32_t bit_vector_size_bits, uint32_t max_compressed_byte_size) : bit_vector_size_bits(bit_vector_size_bits), max_compressed_byte_size(max_compressed_byte_size) {}
     };
 
     size_t zendoo_get_sc_custom_data_size_in_bytes(void);
@@ -115,11 +131,10 @@ extern "C" {
 
     void zendoo_commitment_tree_delete(commitment_tree_t *ptr);
 
-    field_t* zendoo_compute_sc_id(
-        const BufferWithSize* tx_hash,
+    field_t *zendoo_compute_sc_id(
+        const BufferWithSize *tx_hash,
         uint32_t pos,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Adds a Sidechain Creation to the commitment tree. Returns true if operation was successful, false otherwise.
@@ -128,65 +143,61 @@ extern "C" {
      */
     bool zendoo_commitment_tree_add_scc(
         commitment_tree_t *ptr,
-        const field_t* sc_id,
+        const field_t *sc_id,
         uint64_t amount,
-        const BufferWithSize* pub_key,
-        const BufferWithSize* tx_hash,
+        const BufferWithSize *pub_key,
+        const BufferWithSize *tx_hash,
         uint32_t out_idx,
         uint32_t withdrawal_epoch_length,
         uint8_t mc_btr_request_data_length,
-        const BufferWithSize* custom_field_elements_config,
-        const BitVectorElementsConfig* custom_bv_elements_config,
+        const BufferWithSize *custom_field_elements_config,
+        const BitVectorElementsConfig *custom_bv_elements_config,
         size_t custom_bv_elements_config_len,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        const BufferWithSize* custom_creation_data,
-        const field_t* constant,
-        const BufferWithSize* cert_vk,
-        const BufferWithSize* csw_vk,
-        CctpErrorCode* ret_code
-    );
+        const BufferWithSize *custom_creation_data,
+        const field_t *constant,
+        const BufferWithSize *cert_vk,
+        const BufferWithSize *csw_vk,
+        CctpErrorCode *ret_code);
 
     /*
      * Adds a Forward Transfer to the commitment tree. Returns true if operation was successful, false otherwise.
      */
     bool zendoo_commitment_tree_add_fwt(
         commitment_tree_t *ptr,
-        const field_t* sc_id,
+        const field_t *sc_id,
         uint64_t amount,
-        const BufferWithSize* pub_key,
-        const BufferWithSize* mc_return_address,
-        const BufferWithSize* tx_hash,
+        const BufferWithSize *pub_key,
+        const BufferWithSize *mc_return_address,
+        const BufferWithSize *tx_hash,
         uint32_t out_idx,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Adds a Backward Transfer Request to the commitment tree. Returns true if operation was successful, false otherwise.
      */
     bool zendoo_commitment_tree_add_bwtr(
         commitment_tree_t *ptr,
-        const field_t* sc_id,
+        const field_t *sc_id,
         uint64_t sc_fee,
-        const field_t** sc_req_data,
+        const field_t **sc_req_data,
         size_t sc_req_data_len,
-        const BufferWithSize* mc_dest_addr,
-        const BufferWithSize* tx_hash,
+        const BufferWithSize *mc_dest_addr,
+        const BufferWithSize *tx_hash,
         uint32_t out_idx,
-        CctpErrorCode *ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Adds a Ceased Sidechain Withdrawal to the commitment tree. Returns true if operation was successful, false otherwise.
      */
     bool zendoo_commitment_tree_add_csw(
         commitment_tree_t *ptr,
-        const field_t* sc_id,
+        const field_t *sc_id,
         uint64_t amount,
-        const field_t* nullifier,
-        const BufferWithSize* mc_pk_hash,
-        CctpErrorCode *ret_code
-    );
+        const field_t *nullifier,
+        const BufferWithSize *mc_pk_hash,
+        CctpErrorCode *ret_code);
 
     /*
      * Adds a Certificate to the commitment tree. Returns true if operation was successful, false otherwise.
@@ -194,51 +205,47 @@ extern "C" {
      */
     bool zendoo_commitment_tree_add_cert(
         commitment_tree_t *ptr,
-        const field_t* sc_id,
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
-    field_t* zendoo_commitment_tree_get_commitment(
+    field_t *zendoo_commitment_tree_get_commitment(
         commitment_tree_t *ptr,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     // Bit Vectors related declarations
 
-    typedef enum eCompressionAlgorithm {
+    typedef enum eCompressionAlgorithm
+    {
         Uncompressed,
         Bzip2,
         Gzip
-    } CompressionAlgorithm; 
+    } CompressionAlgorithm;
 
-    BufferWithSize* zendoo_compress_bit_vector(
-        const BufferWithSize* buf,
+    BufferWithSize *zendoo_compress_bit_vector(
+        const BufferWithSize *buf,
         CompressionAlgorithm algorithm,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
-    BufferWithSize* zendoo_decompress_bit_vector(
-        const BufferWithSize* buf,
+    BufferWithSize *zendoo_decompress_bit_vector(
+        const BufferWithSize *buf,
         size_t expected_decomp_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
-    field_t* zendoo_merkle_root_from_compressed_bytes(
-        const BufferWithSize* compressed_data,
+    field_t *zendoo_merkle_root_from_compressed_bytes(
+        const BufferWithSize *compressed_data,
         size_t expected_decomp_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
-    //Poseidon hash related functions
+    // Poseidon hash related functions
 
     typedef struct poseidon_hash poseidon_hash_t;
 
@@ -247,12 +254,11 @@ extern "C" {
      * It's possible to customize the initial Poseidon state given a vector of field elements
      * as `personalization`; this is not mandatory and `personalization` can be NULL.
      */
-    poseidon_hash_t* zendoo_init_poseidon_hash_constant_length(
+    poseidon_hash_t *zendoo_init_poseidon_hash_constant_length(
         size_t input_size,
-        const field_t** personalization,
+        const field_t **personalization,
         size_t personalization_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Gets a new variable input length instance of poseidon_hash, specifying (if known a priori)
@@ -260,12 +266,11 @@ extern "C" {
      * It's possible to customize the initial Poseidon state given a vector of field elements
      * as `personalization`; this is not mandatory and `personalization` can be NULL.
      */
-    poseidon_hash_t* zendoo_init_poseidon_hash_variable_length(
+    poseidon_hash_t *zendoo_init_poseidon_hash_variable_length(
         bool mod_rate,
-        const field_t** personalization,
+        const field_t **personalization,
         size_t personalization_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Updates `digest` with a new field element `fe` given an opaque pointer to it.
@@ -273,8 +278,7 @@ extern "C" {
      * NOTE: The function will perform a copy of the FieldElement pointed by `fe` in order to store
      * it as its internal state, therefore it's possible to free `fe` immediately afterwards.
      */
-    bool zendoo_update_poseidon_hash(const field_t* fe, poseidon_hash_t* digest, CctpErrorCode* ret_code);
-
+    bool zendoo_update_poseidon_hash(const field_t *fe, poseidon_hash_t *digest, CctpErrorCode *ret_code);
 
     /*
      * Updates `digest` with a new field element `fe` given a byte array from which deserializing it.
@@ -283,7 +287,7 @@ extern "C" {
      *       internal state, therefore it's possibile to destroy `fe` immediately after having called
      *       this function.
      */
-    bool zendoo_update_poseidon_hash_from_raw(const BufferWithSize* fe, poseidon_hash_t* digest, CctpErrorCode* ret_code);
+    bool zendoo_update_poseidon_hash_from_raw(const BufferWithSize *fe, poseidon_hash_t *digest, CctpErrorCode *ret_code);
 
     /*
      * Returns the final digest.
@@ -294,25 +298,24 @@ extern "C" {
      * will return error if digest was not updated with a number of field elements that is
      * multiple of its rate.
      */
-    field_t* zendoo_finalize_poseidon_hash(const poseidon_hash_t* digest, CctpErrorCode* ret_code);
+    field_t *zendoo_finalize_poseidon_hash(const poseidon_hash_t *digest, CctpErrorCode *ret_code);
 
     /*
      * Restore digest to its initial state, allowing to change `personalization` too if needed.
      * Return true if operation was successfull, false otherwise.
      */
     bool zendoo_reset_poseidon_hash(
-        poseidon_hash_t* digest,
-        const field_t** personalization,
+        poseidon_hash_t *digest,
+        const field_t **personalization,
         size_t personalization_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the poseidon_hash pointed by `digest`.
      * It's caller responsibility to set `digest` to NULL afterwards.
      * If `digest` was already null, the function does nothing.
      */
-    void zendoo_free_poseidon_hash(poseidon_hash_t* digest);
+    void zendoo_free_poseidon_hash(poseidon_hash_t *digest);
 
     /*
      *   Support struct to enhance and make easier the usage of poseidon_hash, by
@@ -320,28 +323,34 @@ extern "C" {
      *   above. Note the definition of the destructor: when an instance of this struct
      *   will go out of scope, the memory Rust-side will be automatically freed.
      */
-    struct ZendooPoseidonHash {
-        poseidon_hash_t* digest;
+    struct ZendooPoseidonHash
+    {
+        poseidon_hash_t *digest;
 
-        ZendooPoseidonHash(poseidon_hash_t* digest): digest(digest) {}
+        ZendooPoseidonHash(poseidon_hash_t *digest) : digest(digest) {}
 
-        bool update(const BufferWithSize* fe, CctpErrorCode* ret_code) {
+        bool update(const BufferWithSize *fe, CctpErrorCode *ret_code)
+        {
             return zendoo_update_poseidon_hash_from_raw(fe, digest, ret_code);
         }
 
-        bool update(field_t* fe, CctpErrorCode* ret_code) {
+        bool update(field_t *fe, CctpErrorCode *ret_code)
+        {
             return zendoo_update_poseidon_hash(fe, digest, ret_code);
         }
 
-        field_t* finalize(CctpErrorCode* ret_code){
+        field_t *finalize(CctpErrorCode *ret_code)
+        {
             return zendoo_finalize_poseidon_hash(digest, ret_code);
         }
 
-        bool reset(const field_t** personalization, size_t personalization_len, CctpErrorCode* ret_code) {
+        bool reset(const field_t **personalization, size_t personalization_len, CctpErrorCode *ret_code)
+        {
             return zendoo_reset_poseidon_hash(digest, personalization, personalization_len, ret_code);
         }
 
-        ~ZendooPoseidonHash() {
+        ~ZendooPoseidonHash()
+        {
             zendoo_free_poseidon_hash(digest);
             digest = nullptr;
         }
@@ -354,13 +363,12 @@ extern "C" {
      * not been updated with exactly the same number of inputs specified at
      * creation time.
      */
-    struct ZendooPoseidonHashConstantLength: ZendooPoseidonHash {
+    struct ZendooPoseidonHashConstantLength : ZendooPoseidonHash
+    {
 
-        ZendooPoseidonHashConstantLength(size_t input_size, CctpErrorCode* ret_code):
-            ZendooPoseidonHash(zendoo_init_poseidon_hash_constant_length(input_size, NULL, 0, ret_code)) {}
+        ZendooPoseidonHashConstantLength(size_t input_size, CctpErrorCode *ret_code) : ZendooPoseidonHash(zendoo_init_poseidon_hash_constant_length(input_size, NULL, 0, ret_code)) {}
 
-        ZendooPoseidonHashConstantLength(size_t input_size, const field_t** personalization, size_t personalization_len, CctpErrorCode* ret_code):
-            ZendooPoseidonHash(zendoo_init_poseidon_hash_constant_length(input_size, personalization, personalization_len, ret_code)) {}
+        ZendooPoseidonHashConstantLength(size_t input_size, const field_t **personalization, size_t personalization_len, CctpErrorCode *ret_code) : ZendooPoseidonHash(zendoo_init_poseidon_hash_constant_length(input_size, personalization, personalization_len, ret_code)) {}
     };
 
     /*
@@ -371,13 +379,12 @@ extern "C" {
      * created with mod_rate = true but it has not been updated with a number
      * of inputs which is effectively multiple of the rate.
      */
-    struct ZendooPoseidonHashVariableLength: ZendooPoseidonHash {
+    struct ZendooPoseidonHashVariableLength : ZendooPoseidonHash
+    {
 
-        ZendooPoseidonHashVariableLength(bool mod_rate, CctpErrorCode* ret_code):
-            ZendooPoseidonHash(zendoo_init_poseidon_hash_variable_length(mod_rate, NULL, 0, ret_code)) {}
+        ZendooPoseidonHashVariableLength(bool mod_rate, CctpErrorCode *ret_code) : ZendooPoseidonHash(zendoo_init_poseidon_hash_variable_length(mod_rate, NULL, 0, ret_code)) {}
 
-        ZendooPoseidonHashVariableLength(bool mod_rate, const field_t** personalization, size_t personalization_len, CctpErrorCode* ret_code):
-            ZendooPoseidonHash(zendoo_init_poseidon_hash_variable_length(mod_rate, personalization, personalization_len, ret_code)) {}
+        ZendooPoseidonHashVariableLength(bool mod_rate, const field_t **personalization, size_t personalization_len, CctpErrorCode *ret_code) : ZendooPoseidonHash(zendoo_init_poseidon_hash_variable_length(mod_rate, personalization, personalization_len, ret_code)) {}
     };
 
     // Merkle Path related functions
@@ -388,22 +395,20 @@ extern "C" {
      * Verify the Merkle Path `path` from `leaf' to `root` for a Merkle Tree of height `height`.
      */
     bool zendoo_verify_ginger_merkle_path(
-        const ginger_merkle_path_t* path,
+        const ginger_merkle_path_t *path,
         size_t height,
-        const field_t* leaf,
-        const field_t* root,
-        CctpErrorCode* ret_code
-    );
+        const field_t *leaf,
+        const field_t *root,
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the Ginger Merkle Path pointed by `path`.
      * It's caller responsibility to set `path` to NULL afterwards.
      * If `path` was already null, the function does nothing.
      */
-    void zendoo_free_ginger_merkle_path(ginger_merkle_path_t* path);
+    void zendoo_free_ginger_merkle_path(ginger_merkle_path_t *path);
 
-
-    //Poseidon-based Merkle Tree related functions
+    // Poseidon-based Merkle Tree related functions
 
     typedef struct ginger_mht ginger_mht_t;
 
@@ -411,7 +416,7 @@ extern "C" {
      * Gets a new instance of a Ginger Merkle Tree, of height `height`.
      * `processing_step` is used to tune the memory usage of the tree.
      */
-    ginger_mht_t* zendoo_new_ginger_mht(size_t height, size_t processing_step, CctpErrorCode* ret_code);
+    ginger_mht_t *zendoo_new_ginger_mht(size_t height, size_t processing_step, CctpErrorCode *ret_code);
 
     /*
      * Appends `leaf` to `tree` given an opaque FieldElement pointer to it.
@@ -419,7 +424,7 @@ extern "C" {
      * NOTE: The function will perform a copy of the FieldElement pointed by `leaf` in order to store
      * it as its internal state, therefore it's possible to free `leaf` immediately afterwards.
      */
-    bool zendoo_append_leaf_to_ginger_mht(const field_t* leaf, ginger_mht_t* tree, CctpErrorCode* ret_code);
+    bool zendoo_append_leaf_to_ginger_mht(const field_t *leaf, ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * Appends `leaf` to `tree` given a byte array from which deserializing a FieldElement.
@@ -428,56 +433,55 @@ extern "C" {
      *       internal state, therefore it's possibile to destroy `fe` immediately after having called
      *       this function.
      */
-    bool zendoo_append_leaf_to_ginger_mht_from_raw(const BufferWithSize* leaf, ginger_mht_t* tree, CctpErrorCode* ret_code);
+    bool zendoo_append_leaf_to_ginger_mht_from_raw(const BufferWithSize *leaf, ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * This function finalizes the computation of the Merkle tree and returns an updated
      * copy of it. This method is idempotent, and calling it multiple times will
      * give the same result. It's also possible to `update` with more inputs in between.
      */
-    ginger_mht_t* zendoo_finalize_ginger_mht(const ginger_mht_t* tree, CctpErrorCode* ret_code);
+    ginger_mht_t *zendoo_finalize_ginger_mht(const ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * This function finalizes the computation of the Merkle tree
      * Once this function is called, it is not possible to further update the tree.
      * Return true if the operation was successfull, false otherwise.
      */
-    bool zendoo_finalize_ginger_mht_in_place(ginger_mht_t* tree, CctpErrorCode* ret_code);
+    bool zendoo_finalize_ginger_mht_in_place(ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * Returns the root of the Merkle Tree. This function must be called on a finalized tree.
      * If not, the function returns null.
      */
-    field_t* zendoo_get_ginger_mht_root(const ginger_mht_t* tree, CctpErrorCode* ret_code);
+    field_t *zendoo_get_ginger_mht_root(const ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * Returns the path from the leaf at `leaf_index` to the root of `tree`.
      * This function must be called on a finalized tree.
      * If not, the function returns null.
      */
-    ginger_merkle_path_t* zendoo_get_ginger_merkle_path(
-        const ginger_mht_t* tree,
+    ginger_merkle_path_t *zendoo_get_ginger_merkle_path(
+        const ginger_mht_t *tree,
         size_t leaf_index,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Returns the value of a node at height h assuming that all its children
      * are recursively empty, starting from a pre-defined empty leaf.
      */
-    field_t* zendoo_get_ginger_empty_node(size_t height);
+    field_t *zendoo_get_ginger_empty_node(size_t height);
 
     /*
      * Restores the tree to its initial state.
      */
-    bool zendoo_reset_ginger_mht(ginger_mht_t* tree, CctpErrorCode* ret_code);
+    bool zendoo_reset_ginger_mht(ginger_mht_t *tree, CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the Ginger Random Access Merkle Tree pointed by `tree`.
      * It's caller responsibility to set `tree` to NULL afterwards.
      * If `tree` was already null, the function does nothing.
      */
-    void zendoo_free_ginger_mht(ginger_mht_t* tree);
+    void zendoo_free_ginger_mht(ginger_mht_t *tree);
 
     /*
      *   Support struct to enhance and make easier the usage of ginger_mht, by
@@ -485,84 +489,92 @@ extern "C" {
      *   above. Note the definition of the destructor: when an instance of this struct
      *   will go out of scope, the memory Rust-side will be automatically freed.
      */
-    struct ZendooGingerMerkleTree {
-        ginger_mht_t* tree;
+    struct ZendooGingerMerkleTree
+    {
+        ginger_mht_t *tree;
 
-        ZendooGingerMerkleTree(ginger_mht_t* tree): tree(tree) {}
+        ZendooGingerMerkleTree(ginger_mht_t *tree) : tree(tree) {}
 
-        ZendooGingerMerkleTree(size_t height, size_t processing_step, CctpErrorCode* ret_code){
+        ZendooGingerMerkleTree(size_t height, size_t processing_step, CctpErrorCode *ret_code)
+        {
             tree = zendoo_new_ginger_mht(height, processing_step, ret_code);
         }
 
-        bool append(const field_t* leaf, CctpErrorCode* ret_code) {
+        bool append(const field_t *leaf, CctpErrorCode *ret_code)
+        {
             return zendoo_append_leaf_to_ginger_mht(leaf, tree, ret_code);
         }
 
-        bool append(const BufferWithSize* leaf, CctpErrorCode* ret_code) {
+        bool append(const BufferWithSize *leaf, CctpErrorCode *ret_code)
+        {
             return zendoo_append_leaf_to_ginger_mht_from_raw(leaf, tree, ret_code);
         }
 
-        ZendooGingerMerkleTree finalize(CctpErrorCode* ret_code){
+        ZendooGingerMerkleTree finalize(CctpErrorCode *ret_code)
+        {
             return ZendooGingerMerkleTree(zendoo_finalize_ginger_mht(tree, ret_code));
         }
 
-        bool finalize_in_place(CctpErrorCode* ret_code){
+        bool finalize_in_place(CctpErrorCode *ret_code)
+        {
             return zendoo_finalize_ginger_mht_in_place(tree, ret_code);
         }
 
-        field_t* root(CctpErrorCode* ret_code){
+        field_t *root(CctpErrorCode *ret_code)
+        {
             return zendoo_get_ginger_mht_root(tree, ret_code);
         }
 
-        ginger_merkle_path_t* get_merkle_path(size_t leaf_index, CctpErrorCode* ret_code) {
+        ginger_merkle_path_t *get_merkle_path(size_t leaf_index, CctpErrorCode *ret_code)
+        {
             return zendoo_get_ginger_merkle_path(tree, leaf_index, ret_code);
         }
 
-        bool reset(CctpErrorCode* ret_code){
+        bool reset(CctpErrorCode *ret_code)
+        {
             return zendoo_reset_ginger_mht(tree, ret_code);
         }
 
-        static field_t* get_empty_node(size_t height) {
+        static field_t *get_empty_node(size_t height)
+        {
             return zendoo_get_ginger_empty_node(height);
         }
 
-        ~ZendooGingerMerkleTree() {
+        ~ZendooGingerMerkleTree()
+        {
             zendoo_free_ginger_mht(tree);
             tree = nullptr;
         }
     };
 
     /* Get an opaque pointer to a random field element */
-    field_t* zendoo_get_random_field(void);
+    field_t *zendoo_get_random_field(void);
 
     /* Get a field element given `value` */
-    field_t* zendoo_get_field_from_long(uint64_t value);
+    field_t *zendoo_get_field_from_long(uint64_t value);
 
     /* Return `true` if the fields pointed by `field_1` and `field_2` are
      * equal, and `false` otherwise.
      */
     bool zendoo_field_assert_eq(
-        const field_t* field_1,
-        const field_t* field_2
-    );
+        const field_t *field_1,
+        const field_t *field_2);
 
-    //SC SNARK related functions
+    // SC SNARK related functions
 
     /*
      * Returns the ProvingSystem instance for which `type_bytes` encodes for.
      */
     ProvingSystem zendoo_get_proving_system_type(
         unsigned char type_byte,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Initialize DLOG keys of specified `segment_size` in memory .
      */
     bool zendoo_init_dlog_keys(
         size_t segment_size,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     typedef struct sc_proof sc_proof_t;
 
@@ -570,55 +582,50 @@ extern "C" {
      * Serialize a proof, in compressed or uncompressed form, depending on the value of `compressed` flag,
      * given an opaque pointer `sc_proof` to it. Instantiate and return a BufferWithSize containing the proof bytes.
      */
-    BufferWithSize* zendoo_serialize_sc_proof(
-        const sc_proof_t* proof,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+    BufferWithSize *zendoo_serialize_sc_proof(
+        const sc_proof_t *proof,
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
     /*
      * Deserialize a proof, in compressed or uncompressed form, depending on the value of `compressed` flag,
      * from `sc_proof_bytes` and return an opaque pointer to it.
      * If `semantic_checks` flag is set, semantic checks on the proof will be performed.
      */
-    sc_proof_t* zendoo_deserialize_sc_proof(
-        const BufferWithSize* sc_proof_bytes,
+    sc_proof_t *zendoo_deserialize_sc_proof(
+        const BufferWithSize *sc_proof_bytes,
         bool semantic_checks,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
     /*
      * Get the ProvingSystem of `sc_proof`.
      */
     ProvingSystem zendoo_get_sc_proof_proving_system_type(
-        const sc_proof_t* sc_proof,
-        CctpErrorCode* ret_code
-    );
+        const sc_proof_t *sc_proof,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_proof serialized to `sc_proof_bytes` BufferWithSize.
      */
     ProvingSystem zendoo_get_sc_proof_proving_system_type_from_buffer(
-        const BufferWithSize* sc_proof_bytes,
-        CctpErrorCode* ret_code
-    );
+        const BufferWithSize *sc_proof_bytes,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_proof serialized to file at `proof_path`.
      */
     ProvingSystem zendoo_get_sc_proof_proving_system_type_from_file(
-        const path_char_t* proof_path,
+        const path_char_t *proof_path,
         size_t proof_path_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the sc_proof pointed by `sc_proof`. It's caller responsibility
      * to set `sc_proof` to NULL afterwards. If `sc_proof` was already NULL, the function does
      * nothing.
      */
-    void zendoo_sc_proof_free(sc_proof_t* proof);
+    void zendoo_sc_proof_free(sc_proof_t *proof);
 
     typedef struct sc_vk sc_vk_t;
 
@@ -626,57 +633,52 @@ extern "C" {
      * from a file at path `vk_path` and return an opaque pointer to it.
      * If `semantic_checks` flag is set, semantic checks on vk will be performed.
      */
-    sc_vk_t* zendoo_deserialize_sc_vk_from_file(
-        const path_char_t* vk_path,
+    sc_vk_t *zendoo_deserialize_sc_vk_from_file(
+        const path_char_t *vk_path,
         size_t vk_path_len,
         bool semantic_checks,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
     /*
      * Deserialize a sc_vk, in compressed or uncompressed form, depending on the value of `compressed` flag,
      * from `sc_vk_bytes` and return an opaque pointer to it.
      * If `semantic_checks` flag is set, semantic checks on vk will be performed.
      */
-    sc_vk_t* zendoo_deserialize_sc_vk(
-        const BufferWithSize* sc_vk_bytes,
+    sc_vk_t *zendoo_deserialize_sc_vk(
+        const BufferWithSize *sc_vk_bytes,
         bool semantic_checks,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
     /*
      * Get the ProvingSystem of `sc_vk`.
      */
     ProvingSystem zendoo_get_sc_vk_proving_system_type(
-        const sc_vk_t* sc_vk,
-        CctpErrorCode* ret_code
-    );
+        const sc_vk_t *sc_vk,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_vk serialized to `sc_vk_bytes` BufferWithSize.
      */
     ProvingSystem zendoo_get_sc_vk_proving_system_type_from_buffer(
-        const BufferWithSize* sc_vk_bytes,
-        CctpErrorCode* ret_code
-    );
+        const BufferWithSize *sc_vk_bytes,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_vk serialized to file at `vk_path`.
      */
     ProvingSystem zendoo_get_sc_vk_proving_system_type_from_file(
-        const path_char_t* vk_path,
+        const path_char_t *vk_path,
         size_t vk_path_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the sc_vk pointed by `sc_vk`. It's caller responsibility
      * to set `sc_vk` to NULL afterwards. If `sc_vk` was already null, the function does
      * nothing.
      */
-    void zendoo_sc_vk_free(sc_vk_t* vk);
+    void zendoo_sc_vk_free(sc_vk_t *vk);
 
     /*  Verify a certificate proof sc_proof `sc_proof` given its corresponding sc_vk `sc_vk`
      *  and all the data needed to construct proof's public inputs. Return true if
@@ -684,46 +686,44 @@ extern "C" {
      *  NOTE: `constant`, `custom_fields` and 'bt_list' can be NULL.
      */
     bool zendoo_verify_certificate_proof(
-        const field_t* constant,
-        const field_t* sc_id,
+        const field_t *constant,
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        const sc_proof_t* sc_proof,
-        const sc_vk_t*    sc_vk,
-        const field_t* sc_prev_wcert_hash,
-        CctpErrorCode* ret_code
-    );
+        const sc_proof_t *sc_proof,
+        const sc_vk_t *sc_vk,
+        const field_t *sc_prev_wcert_hash,
+        CctpErrorCode *ret_code);
 
     /*
      * Return a field element to be used as `cert_data_hash` input for
      * `zendoo_verify_csw_proof()` and `zendoo_add_csw_proof_to_batch_verifier()`
      * when no `cert_data_hash` is present.
      */
-    field_t* zendoo_get_phantom_cert_data_hash();
+    field_t *zendoo_get_phantom_cert_data_hash();
 
     /*
      * Compute cert data hash.
      */
-    field_t* zendoo_get_cert_data_hash(
-        const field_t* sc_id,
+    field_t *zendoo_get_cert_data_hash(
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*  Verify a CSW proof sc_proof `sc_proof` given its corresponding sc_vk `sc_vk`
      *  and all the data needed to construct proof's public inputs. Return true if
@@ -733,23 +733,22 @@ extern "C" {
      */
     bool zendoo_verify_csw_proof(
         uint64_t amount,
-        const field_t* constant,
-        const field_t* sc_id,
-        const field_t* nullifier,
-        const BufferWithSize* mc_pk_hash,
-        const field_t* cert_data_hash,
-        const field_t* end_cum_comm_tree_root,
-        const sc_proof_t* sc_proof,
-        const sc_vk_t*    sc_vk,
-        CctpErrorCode* ret_code
-    );
+        const field_t *constant,
+        const field_t *sc_id,
+        const field_t *nullifier,
+        const BufferWithSize *mc_pk_hash,
+        const field_t *cert_data_hash,
+        const field_t *end_cum_comm_tree_root,
+        const sc_proof_t *sc_proof,
+        const sc_vk_t *sc_vk,
+        CctpErrorCode *ret_code);
 
     typedef struct sc_batch_proof_verifier sc_batch_proof_verifier_t;
 
     /*
      * Return an instance of sc_batch_proof_verifier
      */
-    sc_batch_proof_verifier_t* zendoo_create_batch_proof_verifier();
+    sc_batch_proof_verifier_t *zendoo_create_batch_proof_verifier();
 
     /* Add a certificate proof to the batch of proofs to be verified, given
      * all the data required to reconstruct the public inputs, the proof
@@ -761,67 +760,65 @@ extern "C" {
      *         state, so they can be immediately freed afterwards.
      */
     bool zendoo_add_certificate_proof_to_batch_verifier(
-        sc_batch_proof_verifier_t* batch_verifier,
+        sc_batch_proof_verifier_t *batch_verifier,
         uint32_t proof_id,
-        const field_t* constant,
-        const field_t* sc_id,
+        const field_t *constant,
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        const sc_proof_t* sc_proof,
-        const sc_vk_t*    sc_vk,
-        const field_t* sc_prev_wcert_hash,
-        CctpErrorCode* ret_code
-    );
+        const sc_proof_t *sc_proof,
+        const sc_vk_t *sc_vk,
+        const field_t *sc_prev_wcert_hash,
+        CctpErrorCode *ret_code);
 
     /*  Verify a CSW proof sc_proof `sc_proof` given its corresponding sc_vk `sc_vk`
      *  and all the data needed to construct proof's public inputs. Return true if
      *  proof verification was successful, false otherwise.
      *  `cert_data_hash` can be NULL and, if so, it will be replaced with a phantom value.
-     *  NOTE: 
+     *  NOTE:
      *      - `constant` can be NULL;
      *      - proof, vk and the public input derived from the other data will be
      *        copied in order to store them in `batch_verifier` state, so they
      *        can be immediately freed afterwards.
      */
     bool zendoo_add_csw_proof_to_batch_verifier(
-        sc_batch_proof_verifier_t* batch_verifier,
+        sc_batch_proof_verifier_t *batch_verifier,
         uint32_t proof_id,
         uint64_t amount,
-        const field_t* constant,
-        const field_t* sc_id,
-        const field_t* nullifier,
-        const BufferWithSize* mc_pk_hash,
-        const field_t* cert_data_hash,
-        const field_t* end_cum_comm_tree_root,
-        const sc_proof_t* sc_proof,
-        const sc_vk_t*    sc_vk,
-        CctpErrorCode* ret_code
-    );
+        const field_t *constant,
+        const field_t *sc_id,
+        const field_t *nullifier,
+        const BufferWithSize *mc_pk_hash,
+        const field_t *cert_data_hash,
+        const field_t *end_cum_comm_tree_root,
+        const sc_proof_t *sc_proof,
+        const sc_vk_t *sc_vk,
+        CctpErrorCode *ret_code);
 
     /* Wraps the result of a batch verification.
      * If result == true, failing_proof should be set to -1;
      * If result == false, failing proof should be set to the id of the failing proof,
      * if it's possibile to estabilish it, to -1 otherwise.
      */
-    struct ZendooBatchProofVerifierResult {
-        bool            result;
-        const uint32_t* failing_proofs;
-        size_t          failing_proofs_len;
+    struct ZendooBatchProofVerifierResult
+    {
+        bool result;
+        const uint32_t *failing_proofs;
+        size_t failing_proofs_len;
 
-        ZendooBatchProofVerifierResult(): failing_proofs(NULL), failing_proofs_len(0) {}
-        ZendooBatchProofVerifierResult(const uint32_t* failing_proofs, size_t failing_proofs_len):
-            failing_proofs(failing_proofs), failing_proofs_len(failing_proofs_len) {}
+        ZendooBatchProofVerifierResult() : failing_proofs(NULL), failing_proofs_len(0) {}
+        ZendooBatchProofVerifierResult(const uint32_t *failing_proofs, size_t failing_proofs_len) : failing_proofs(failing_proofs), failing_proofs_len(failing_proofs_len) {}
     };
 
     /* Free a BufferWithSize allocated Rust-side */
-    void zendoo_free_batch_proof_verifier_result(ZendooBatchProofVerifierResult* result);
+    void zendoo_free_batch_proof_verifier_result(ZendooBatchProofVerifierResult *result);
 
     /*
      * Pause all running low priority threads (currently is possible only for the batch verifier threads).
@@ -839,11 +836,10 @@ extern "C" {
      * verifications (if any) happening in other threads as soon as possible;
      * this means also that a high priority verification cannot be paused.
      */
-    ZendooBatchProofVerifierResult* zendoo_batch_verify_all_proofs(
-        const sc_batch_proof_verifier_t* batch_verifier,
+    ZendooBatchProofVerifierResult *zendoo_batch_verify_all_proofs(
+        const sc_batch_proof_verifier_t *batch_verifier,
         bool prioritize,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Perform batch verification of the proofs added to `batch_verifier`
@@ -852,18 +848,17 @@ extern "C" {
      * in other threads as soon as possible; this means also that a high priority
      * verification cannot be paused.
      */
-    ZendooBatchProofVerifierResult* zendoo_batch_verify_proofs_by_id(
-        const sc_batch_proof_verifier_t* batch_verifier,
-        const uint32_t* ids_list,
+    ZendooBatchProofVerifierResult *zendoo_batch_verify_proofs_by_id(
+        const sc_batch_proof_verifier_t *batch_verifier,
+        const uint32_t *ids_list,
         size_t ids_list_len,
         bool prioritize,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory pointed by `batch_verifier`,
-    */
-    void zendoo_free_batch_proof_verifier(sc_batch_proof_verifier_t* batch_verifier);
+     */
+    void zendoo_free_batch_proof_verifier(sc_batch_proof_verifier_t *batch_verifier);
 
     /*
      *   Support struct to enhance and make easier the usage of sc_batch_proof_verifier, by
@@ -871,84 +866,85 @@ extern "C" {
      *   above. Note the definition of the destructor: when an instance of this struct
      *   will go out of scope, the memory Rust-side will be automatically freed.
      */
-    struct ZendooBatchProofVerifier {
-        sc_batch_proof_verifier_t* batch_verifier;
+    struct ZendooBatchProofVerifier
+    {
+        sc_batch_proof_verifier_t *batch_verifier;
         bool highPriorityVerification;
 
-        ZendooBatchProofVerifier(sc_batch_proof_verifier_t* batch_verifier, bool highPriorityVerification):
-         batch_verifier(batch_verifier), highPriorityVerification(highPriorityVerification) {}
+        ZendooBatchProofVerifier(sc_batch_proof_verifier_t *batch_verifier, bool highPriorityVerification) : batch_verifier(batch_verifier), highPriorityVerification(highPriorityVerification) {}
 
-        ZendooBatchProofVerifier(bool highPriorityVerification): highPriorityVerification(highPriorityVerification) {
+        ZendooBatchProofVerifier(bool highPriorityVerification) : highPriorityVerification(highPriorityVerification)
+        {
             batch_verifier = zendoo_create_batch_proof_verifier();
         }
 
-        ZendooBatchProofVerifier() {
+        ZendooBatchProofVerifier()
+        {
             batch_verifier = zendoo_create_batch_proof_verifier();
             highPriorityVerification = false;
         }
 
         bool add_certificate_proof(
             uint32_t proof_id,
-            const field_t* constant,
-            const field_t* sc_id,
+            const field_t *constant,
+            const field_t *sc_id,
             uint32_t epoch_number,
             uint64_t quality,
-            const backward_transfer_t* bt_list,
+            const backward_transfer_t *bt_list,
             size_t bt_list_len,
-            const field_t** custom_fields,
+            const field_t **custom_fields,
             size_t custom_fields_len,
-            const field_t* end_cum_comm_tree_root,
+            const field_t *end_cum_comm_tree_root,
             uint64_t btr_fee,
             uint64_t ft_min_amount,
-            const sc_proof_t* sc_proof,
-            const sc_vk_t*    sc_vk,
-            const field_t* sc_prev_wcert_hash,
-            CctpErrorCode* ret_code
-        )
+            const sc_proof_t *sc_proof,
+            const sc_vk_t *sc_vk,
+            const field_t *sc_prev_wcert_hash,
+            CctpErrorCode *ret_code)
         {
             return zendoo_add_certificate_proof_to_batch_verifier(
                 batch_verifier, proof_id, constant, sc_id, epoch_number, quality,
                 bt_list, bt_list_len, custom_fields, custom_fields_len,
                 end_cum_comm_tree_root, btr_fee, ft_min_amount,
-                sc_proof, sc_vk, sc_prev_wcert_hash, ret_code
-            );
+                sc_proof, sc_vk, sc_prev_wcert_hash, ret_code);
         }
 
         bool add_csw_proof(
             uint32_t proof_id,
             uint64_t amount,
-            const field_t* constant,
-            const field_t* sc_id,
-            const field_t* nullifier,
-            const BufferWithSize* mc_pk_hash,
-            const field_t* cert_data_hash,
-            const field_t* end_cum_comm_tree_root,
-            const sc_proof_t* sc_proof,
-            const sc_vk_t*    sc_vk,
-            CctpErrorCode* ret_code
-        )
+            const field_t *constant,
+            const field_t *sc_id,
+            const field_t *nullifier,
+            const BufferWithSize *mc_pk_hash,
+            const field_t *cert_data_hash,
+            const field_t *end_cum_comm_tree_root,
+            const sc_proof_t *sc_proof,
+            const sc_vk_t *sc_vk,
+            CctpErrorCode *ret_code)
         {
             return zendoo_add_csw_proof_to_batch_verifier(
                 batch_verifier, proof_id, amount, constant, sc_id, nullifier, mc_pk_hash,
-                cert_data_hash, end_cum_comm_tree_root, sc_proof, sc_vk, ret_code
-            );
+                cert_data_hash, end_cum_comm_tree_root, sc_proof, sc_vk, ret_code);
         }
 
-        ZendooBatchProofVerifierResult* batch_verify_all(CctpErrorCode* ret_code) {
+        ZendooBatchProofVerifierResult *batch_verify_all(CctpErrorCode *ret_code)
+        {
             return zendoo_batch_verify_all_proofs(batch_verifier, highPriorityVerification, ret_code);
         }
 
-        ZendooBatchProofVerifierResult* batch_verify_subset(const uint32_t* ids_list, size_t ids_list_len, CctpErrorCode* ret_code) {
+        ZendooBatchProofVerifierResult *batch_verify_subset(const uint32_t *ids_list, size_t ids_list_len, CctpErrorCode *ret_code)
+        {
             return zendoo_batch_verify_proofs_by_id(batch_verifier, ids_list, ids_list_len, highPriorityVerification, ret_code);
         }
-        
-        ~ZendooBatchProofVerifier() {
+
+        ~ZendooBatchProofVerifier()
+        {
             zendoo_free_batch_proof_verifier(batch_verifier);
             batch_verifier = nullptr;
         }
     };
 
-    //Test functions
+    // Test functions
 
     typedef struct sc_pk sc_pk_t;
 
@@ -957,60 +953,56 @@ extern "C" {
      * If `semantic_checks` flag is set, group membership test for curve points will be performed.
      * Return NULL if the file doesn't exist, if deserialization fails or validity checks fail.
      */
-    sc_pk_t* zendoo_deserialize_sc_pk_from_file(
-        const path_char_t* pk_path,
+    sc_pk_t *zendoo_deserialize_sc_pk_from_file(
+        const path_char_t *pk_path,
         size_t pk_path_len,
         bool semantic_checks,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
     /*
      * Get the ProvingSystem of `sc_pk`.
      */
     ProvingSystem zendoo_get_sc_pk_proving_system_type(
-        const sc_pk_t* pk,
-        CctpErrorCode* ret_code
-    );
+        const sc_pk_t *pk,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_pk serialized to `sc_pk_bytes` BufferWithSize.
      */
     ProvingSystem zendoo_get_sc_pk_proving_system_type_from_buffer(
-        const BufferWithSize* sc_pk_bytes,
-        CctpErrorCode* ret_code
-    );
+        const BufferWithSize *sc_pk_bytes,
+        CctpErrorCode *ret_code);
 
     /*
      * Get the ProvingSystem of the sc_pk serialized to file at `pk_path`.
      */
     ProvingSystem zendoo_get_sc_pk_proving_system_type_from_file(
-        const path_char_t* pk_path,
+        const path_char_t *pk_path,
         size_t pk_path_len,
-        CctpErrorCode* ret_code
-    );
+        CctpErrorCode *ret_code);
 
     /*
      * Free the memory from the sc_pk pointed by `sc_pk`. It's caller responsibility
      * to set `sc_pk` to NULL afterwards. If `sc_pk` was already null, the function does
      * nothing.
      */
-    void zendoo_sc_pk_free(sc_pk_t* pk);
+    void zendoo_sc_pk_free(sc_pk_t *pk);
 
     /* Deserialize a sc_proof, in compressed or uncompressed form, depending on the value of `compressed` flag,
      * from a file at path `proof_path` and return an opaque pointer to it.
      * If `semantic_checks` flag is set, group membership test for curve points will be performed.
      * Return NULL if the file doesn't exist, if deserialization fails or validity checks fail.
      */
-    sc_proof_t* zendoo_deserialize_sc_proof_from_file(
-        const path_char_t* proof_path,
+    sc_proof_t *zendoo_deserialize_sc_proof_from_file(
+        const path_char_t *proof_path,
         size_t proof_path_len,
         bool semantic_checks,
-        CctpErrorCode* ret_code,
-        bool compressed = true
-    );
+        CctpErrorCode *ret_code,
+        bool compressed = true);
 
-    typedef enum class TestCircuitType {
+    typedef enum class TestCircuitType
+    {
         Undefined,
         Certificate,
         CertificateNoConstant,
@@ -1028,12 +1020,12 @@ extern "C" {
         ProvingSystem ps_type,
         uint32_t num_constraints,
         bool with_prev_hash,
-        const path_char_t* params_dir,
+        const path_char_t *params_dir,
         size_t params_dir_len,
-        CctpErrorCode* ret_code,
+        CctpErrorCode *ret_code,
         bool compress_vk = true,
         bool compress_pk = true,
-        const uint32_t* segment_size = nullptr // defaults to max segment size
+        const uint32_t *segment_size = nullptr // defaults to max segment size
     );
 
     /*
@@ -1044,25 +1036,25 @@ extern "C" {
      */
     bool zendoo_create_cert_test_proof(
         bool zk,
-        const field_t* constant,
-        const field_t* sc_id,
+        const field_t *constant,
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        const sc_pk_t* pk,
-        const path_char_t* proof_path,
+        const sc_pk_t *pk,
+        const path_char_t *proof_path,
         size_t proof_path_len,
         uint32_t num_constraints,
-        const field_t* sc_prev_wcert_hash,
-        CctpErrorCode* ret_code,
+        const field_t *sc_prev_wcert_hash,
+        CctpErrorCode *ret_code,
         bool compress_proof = true,
-        const uint32_t* segment_size = nullptr // defaults to max segment size
+        const uint32_t *segment_size = nullptr // defaults to max segment size
     );
 
     /*
@@ -1073,22 +1065,22 @@ extern "C" {
      *     - `constant` can be null.
      *     - `cert_data_hash` can be NULL and, if so, it will be replaced with a phantom value.
      */
-     bool zendoo_create_csw_test_proof(
+    bool zendoo_create_csw_test_proof(
         bool zk,
         uint64_t amount,
-        const field_t* constant,
-        const field_t* sc_id,
-        const field_t* nullifier,
-        const BufferWithSize* mc_pk_hash,
-        const field_t* cert_data_hash,
-        const field_t* end_cum_comm_tree_root,
-        const sc_pk_t* pk,
-        const path_char_t* proof_path,
+        const field_t *constant,
+        const field_t *sc_id,
+        const field_t *nullifier,
+        const BufferWithSize *mc_pk_hash,
+        const field_t *cert_data_hash,
+        const field_t *end_cum_comm_tree_root,
+        const sc_pk_t *pk,
+        const path_char_t *proof_path,
         size_t proof_path_len,
         uint32_t num_constraints,
-        CctpErrorCode* ret_code,
+        CctpErrorCode *ret_code,
         bool compress_proof = true,
-        const uint32_t* segment_size = nullptr // defaults to max segment size
+        const uint32_t *segment_size = nullptr // defaults to max segment size
     );
 
     /*
@@ -1097,24 +1089,24 @@ extern "C" {
      * NOTE: `constant`, `bt_list` and `custom_fields` can be null.
      * Return true if operation was successful, false otherwise.
      */
-    BufferWithSize* zendoo_create_return_cert_test_proof(
+    BufferWithSize *zendoo_create_return_cert_test_proof(
         bool zk,
-        const field_t* constant,
-        const field_t* sc_id,
+        const field_t *constant,
+        const field_t *sc_id,
         uint32_t epoch_number,
         uint64_t quality,
-        const backward_transfer_t* bt_list,
+        const backward_transfer_t *bt_list,
         size_t bt_list_len,
-        const field_t** custom_fields,
+        const field_t **custom_fields,
         size_t custom_fields_len,
-        const field_t* end_cum_comm_tree_root,
+        const field_t *end_cum_comm_tree_root,
         uint64_t btr_fee,
         uint64_t ft_min_amount,
-        const sc_pk_t* pk,
+        const sc_pk_t *pk,
         uint32_t num_constraints,
-        CctpErrorCode* ret_code,
+        CctpErrorCode *ret_code,
         bool compress_proof = true,
-        const uint32_t* segment_size = nullptr // defaults to max segment size
+        const uint32_t *segment_size = nullptr // defaults to max segment size
     );
 
     /*
@@ -1123,29 +1115,20 @@ extern "C" {
      * Return true if operation was successful, false otherwise.
      * `cert_data_hash` can be NULL and, if so, it will be replaced with a phantom value.
      */
-     BufferWithSize* zendoo_create_return_csw_test_proof(
+    BufferWithSize *zendoo_create_return_csw_test_proof(
         bool zk,
         uint64_t amount,
-        const field_t* sc_id,
-        const field_t* nullifier,
-        const BufferWithSize* mc_pk_hash,
-        const field_t* cert_data_hash,
-        const field_t* end_cum_comm_tree_root,
-        const sc_pk_t* pk,
+        const field_t *sc_id,
+        const field_t *nullifier,
+        const BufferWithSize *mc_pk_hash,
+        const field_t *cert_data_hash,
+        const field_t *end_cum_comm_tree_root,
+        const sc_pk_t *pk,
         uint32_t num_constraints,
-        CctpErrorCode* ret_code,
+        CctpErrorCode *ret_code,
         bool compress_proof = true,
-        const uint32_t* segment_size = nullptr // defaults to max segment size
+        const uint32_t *segment_size = nullptr // defaults to max segment size
     );
-
-     /* Return `true` if the proofs pointed by `sc_proof_1` and `sc_proof_2` are
-      * equal, and `false` otherwise.
-      */
-     bool zendoo_sc_proof_assert_eq(
-         const sc_proof_t* sc_proof_1,
-         const sc_proof_t* sc_proof_2
-     );
-
 }
 
 #endif // ZENDOO_MC_INCLUDE_H_

--- a/mc_test/callFromMTFExample.py
+++ b/mc_test/callFromMTFExample.py
@@ -312,3 +312,8 @@ if __name__ == "__main__":
     else:
         print('Unknown test')
         sys.exit(2)
+
+    # Delete log files
+    for fname in os.listdir(data_dir):
+        if fname.startswith("test_log"):
+            os.remove(os.path.join(data_dir, fname))

--- a/mc_test/mcTestCall.cpp
+++ b/mc_test/mcTestCall.cpp
@@ -360,8 +360,20 @@ CreateParameters parse_args(int argc, char** argv, Operation op, ParseFn parse_f
 }
 
 void init(Parameters const& pars, int segment_size) {
-    // Load DLOG keys
     CctpErrorCode ret_code = CctpErrorCode::OK;
+
+    // Init library
+    const char* log_config_path = "../src/tests/log/sample_log_config.yaml";
+    zendoo_init(
+        (path_char_t const*) log_config_path,
+        strlen(log_config_path),
+        &ret_code
+    );
+    if (ret_code != CctpErrorCode::OK) {
+        printError(__func__, __LINE__, "Failed initializing library");
+    }
+
+    // Load DLOG keys
     zendoo_init_dlog_keys(segment_size, &ret_code);
     if (ret_code != CctpErrorCode::OK) {
         printError(__func__, __LINE__, "Failed initializing dlog keys");
@@ -641,7 +653,7 @@ void create_verify(CreateParameters const& pars)
 }
 
 int run(int argc, char** argv, int seg_size, ParseFn parser)
-{
+{    
     if (argc < 2) printUsage(argv[0]);
 
     if (strcmp(argv[1], "generate") == 0) {

--- a/mc_test/mcTestCall.cpp
+++ b/mc_test/mcTestCall.cpp
@@ -1,7 +1,8 @@
 #include "zendoo_mc.h"
 #include "mcTestCall.h"
-
 #include "hex_utils.h"
+
+#include <sys/stat.h> // stat
 #include <cstdarg>
 #include <iostream>
 #include <cassert>
@@ -54,6 +55,7 @@ struct Parameters {
     uint32_t        num_constraints = 1024;
     char const*     params_dir      = nullptr;
     char const*     proof_path      = nullptr;
+    char const*     log_config_path = "../src/tests/log/sample_log_config.yaml";
 };
 
 struct CreateParameters : Parameters {
@@ -154,6 +156,11 @@ void printError(char const* func, uint32_t line, Parameters const* pars, char co
     printError(func, line, msg);
 }
 
+bool file_exists(char const* filename) {
+  struct stat buffer;
+  return (stat(filename, &buffer) == 0);
+}
+
 std::string get_key_path(Parameters const& pars, bool is_verification) {
     std::stringstream res;
     res << pars.params_dir << pars.ps_type_raw;
@@ -222,7 +229,7 @@ CreateParameters parse_args(int argc, char** argv, Operation op, ParseFn parse_f
 
     res.op = op;
 
-    while ((opt = getopt(argc, argv, "c:k:p:s:n:rvz")) != -1) {
+    while ((opt = getopt(argc, argv, "c:k:p:s:n:l:rvz")) != -1) {
         switch (opt) {
         case 'c':
             circuit = optarg;
@@ -251,6 +258,9 @@ CreateParameters parse_args(int argc, char** argv, Operation op, ParseFn parse_f
             break;
         case 'z':
             res.zk = true;
+            break;
+        case 'l':
+            res.log_config_path = optarg;
             break;
         }
     }
@@ -363,10 +373,12 @@ void init(Parameters const& pars, int segment_size) {
     CctpErrorCode ret_code = CctpErrorCode::OK;
 
     // Init library
-    const char* log_config_path = "../src/tests/log/sample_log_config.yaml";
+    if (!file_exists(pars.log_config_path)) {
+        printError(__func__, __LINE__, "Cannot read config file %s", pars.log_config_path);
+    }
     zendoo_init(
-        (path_char_t const*) log_config_path,
-        strlen(log_config_path),
+        (path_char_t const*) pars.log_config_path,
+        strlen(pars.log_config_path),
         &ret_code
     );
     if (ret_code != CctpErrorCode::OK) {
@@ -653,7 +665,7 @@ void create_verify(CreateParameters const& pars)
 }
 
 int run(int argc, char** argv, int seg_size, ParseFn parser)
-{    
+{
     if (argc < 2) printUsage(argv[0]);
 
     if (strcmp(argv[1], "generate") == 0) {

--- a/mc_test/test.sh
+++ b/mc_test/test.sh
@@ -1,2 +1,0 @@
-make
-python callFromMTFExample.py

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use lazy_static::lazy_static;
 use libc::{c_uchar, c_uint};
 use rand::rngs::OsRng;
 use std::sync::{Arc, Condvar, Mutex};
-use std::{convert::TryInto, fmt::Write, panic, path::Path, ptr::null_mut, slice,};
+use std::{convert::TryInto, fmt::Write, panic, path::Path, ptr::null_mut, slice};
 lazy_static! {
     pub static ref STOP_CTR: Arc<(Mutex<usize>, Condvar)> =
         Arc::new((Mutex::new(0), Condvar::new()));
@@ -128,7 +128,8 @@ pub extern "C" fn zendoo_init(
     ret_code: &mut CctpErrorCode,
 ) {
     // Read config file path
-    let path_str = OsString::from_wide(unsafe { slice::from_raw_parts(config_path, config_path_len) });
+    let path_str =
+        OsString::from_wide(unsafe { slice::from_raw_parts(config_path, config_path_len) });
     let config_path = Path::new(&path_str);
 
     // Init logger

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub extern "C" fn zendoo_init(
     match init_logger(config_path) {
         Ok(()) => *ret_code = CctpErrorCode::OK,
         Err(e) => {
-            log::error!("Error initializing logger: {:?}", e);
+            eprintln!("Error initializing logger: {:?}", e);
             *ret_code = CctpErrorCode::GenericError
         }
     }
@@ -439,7 +439,7 @@ pub extern "C" fn zendoo_commitment_tree_get_commitment(
         Some(commitment) => Box::into_raw(Box::new(commitment)),
         None => {
             *ret_code = CctpErrorCode::GenericError;
-            log::error!("{:?}", "get_commitment() failed!");
+            log::error!("get_commitment() failed!");
             null_mut()
         }
     }
@@ -495,7 +495,7 @@ pub extern "C" fn zendoo_decompress_bit_vector(
             Box::into_raw(Box::new(bit_vector_buffer))
         }
         Err(e) => {
-            log::error!("===> {}", e);
+            log::error!("decompress_bit_vector() failed: {:?}", e.to_string());
             *ret_code = CctpErrorCode::UncompressError;
             null_mut()
         }
@@ -514,7 +514,7 @@ pub extern "C" fn zendoo_merkle_root_from_compressed_bytes(
     match merkle_root_from_compressed_bytes(compressed_slice, expected_uncompressed_size) {
         Ok(x) => Box::into_raw(Box::new(x)),
         Err(e) => {
-            log::error!("===> {}", e);
+            log::error!("merkle_root_from_compressed_bytes() failed: {:?}", e.to_string());
             *ret_code = CctpErrorCode::MerkleRootBuildError;
             null_mut()
         }
@@ -585,7 +585,7 @@ fn _zendoo_init_dlog_keys(max_segment_size: usize, ret_code: &mut CctpErrorCode)
     match init_dlog_keys(ProvingSystem::Darlin, max_segment_size) {
         Ok(()) => true,
         Err(e) => {
-            log::error!("{:?}", format!("Error bootstrapping DLOG keys: {:?}", e));
+            log::error!("Error bootstrapping DLOG keys: {:?}", e);
             *ret_code = CctpErrorCode::GenericError;
             false
         }
@@ -630,7 +630,7 @@ pub extern "C" fn zendoo_serialize_sc_proof(
             Box::into_raw(Box::new(BufferWithSize { data, len }))
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error serializing proof {:?}", e));
+            log::error!("Error serializing proof {:?}", e);
             *ret_code = CctpErrorCode::InvalidValue;
             null_mut()
         }
@@ -999,7 +999,7 @@ pub extern "C" fn zendoo_verify_certificate_proof(
     ) {
         Ok(res) => res,
         Err(e) => {
-            log::error!("{:?}", format!("Proof verification failure {:?}", e));
+            log::error!("Proof verification failure {:?}", e);
             match e {
                 ProvingSystemError::ProofVerificationFailed(_) => *ret_code = CctpErrorCode::OK,
                 _ => *ret_code = CctpErrorCode::ProofVerificationFailure,
@@ -1107,7 +1107,7 @@ pub extern "C" fn zendoo_get_cert_data_hash(
     ) {
         Ok(hash) => Box::into_raw(Box::new(hash)),
         Err(e) => {
-            log::error!("{:?}", format!("Error computing cert_data_hash: {:?}", e));
+            log::error!("Error computing cert_data_hash: {:?}", e);
             *ret_code = CctpErrorCode::HashingError;
             null_mut()
         }
@@ -1155,7 +1155,7 @@ pub extern "C" fn zendoo_verify_csw_proof(
     ) {
         Ok(res) => res,
         Err(e) => {
-            log::error!("{:?}", format!("Proof verification failure {:?}", e));
+            log::error!("Proof verification failure {:?}", e);
             match e {
                 ProvingSystemError::ProofVerificationFailed(_) => *ret_code = CctpErrorCode::OK,
                 _ => *ret_code = CctpErrorCode::ProofVerificationFailure,
@@ -1263,7 +1263,7 @@ pub extern "C" fn zendoo_add_certificate_proof_to_batch_verifier(
     ) {
         Ok(()) => true,
         Err(e) => {
-            log::error!("{:?}", format!("Error adding proof to the batch: {:?}", e));
+            log::error!("Error adding proof to the batch: {:?}", e);
             *ret_code = CctpErrorCode::BatchVerifierFailure;
             false
         }
@@ -1317,7 +1317,7 @@ pub extern "C" fn zendoo_add_csw_proof_to_batch_verifier(
     ) {
         Ok(()) => true,
         Err(e) => {
-            log::error!("{:?}", format!("Error adding proof to the batch: {:?}", e));
+            log::error!("Error adding proof to the batch: {:?}", e);
             *ret_code = CctpErrorCode::BatchVerifierFailure;
             false
         }
@@ -1398,7 +1398,7 @@ pub extern "C" fn zendoo_batch_verify_all_proofs(
     let result = match get_batch_verifier_thread_pool(prioritize) {
         Ok(pool) => pool.install(|| rs_batch_verifier.batch_verify_all(&mut OsRng::default())),
         Err(e) => {
-            log::error!("{:?}", e);
+            log::error!("Unable to initialize thread pool for proof verification {:?}", e);
             *ret_code = CctpErrorCode::GenericError;
             return null_mut();
         }
@@ -1417,7 +1417,7 @@ pub extern "C" fn zendoo_batch_verify_all_proofs(
 
         // Otherwise, return the indices of the failing proofs if it's possible to estabilish it.
         Err(e) => {
-            log::error!("{:?}", format!("Batch proof verification failure: {:?}", e));
+            log::error!("Batch proof verification failure: {:?}", e);
             match e {
                 ProvingSystemError::FailedBatchVerification(maybe_ids) => {
                     *ret_code = CctpErrorCode::OK;
@@ -1466,7 +1466,7 @@ pub extern "C" fn zendoo_batch_verify_proofs_by_id(
             rs_batch_verifier.batch_verify_subset(rs_ids_list.to_vec(), &mut OsRng::default())
         }),
         Err(e) => {
-            log::error!("{:?}", e);
+            log::error!("Unable to initialize thread pool for batch verification: {:?}", e);
             *ret_code = CctpErrorCode::GenericError;
             return null_mut();
         }
@@ -1488,7 +1488,7 @@ pub extern "C" fn zendoo_batch_verify_proofs_by_id(
 
         // Otherwise, return the indices of the failing proofs if it's possible to estabilish it.
         Err(e) => {
-            log::error!("{:?}", format!("Batch proof verification failure: {:?}", e));
+            log::error!("Batch proof verification failure: {:?}", e);
             match e {
                 ProvingSystemError::FailedBatchVerification(maybe_ids) => {
                     *ret_code = CctpErrorCode::OK;
@@ -1592,7 +1592,7 @@ pub extern "C" fn zendoo_update_poseidon_hash_from_raw(
         }
         Err(e) => {
             *ret_code = CctpErrorCode::InvalidBufferData;
-            log::error!("{:?}", format!("Error deserializing input: {:?}", e));
+            log::error!("Error deserializing input: {:?}", e);
             false
         }
     }
@@ -1608,7 +1608,7 @@ pub extern "C" fn zendoo_finalize_poseidon_hash(
     match finalize_poseidon_hash(digest) {
         Ok(output) => Box::into_raw(Box::new(output)),
         Err(e) => {
-            log::error!("{:?}", format!("Error finalizing the hash: {:?}", e));
+            log::error!("Error finalizing the hash: {:?}", e);
             *ret_code = CctpErrorCode::HashingError;
             null_mut()
         }
@@ -1650,7 +1650,7 @@ pub extern "C" fn zendoo_new_ginger_mht(
     match new_ginger_mht(height, processing_step) {
         Ok(gmt) => Box::into_raw(Box::new(gmt)),
         Err(e) => {
-            log::error!("{:?}", format!("New merkle tree error: {:?}", e));
+            log::error!("New merkle tree error: {:?}", e);
             *ret_code = CctpErrorCode::MerkleRootBuildError;
             null_mut()
         }
@@ -1670,7 +1670,7 @@ pub extern "C" fn zendoo_append_leaf_to_ginger_mht(
         Ok(_) => true,
         Err(e) => {
             *ret_code = CctpErrorCode::MerkleTreeError;
-            log::error!("{:?}", format!("Error appending leaf: {:?}", e));
+            log::error!("Error appending leaf: {:?}", e);
             false
         }
     }
@@ -1696,7 +1696,7 @@ pub extern "C" fn zendoo_append_leaf_to_ginger_mht_from_raw(
                 Ok(_) => true,
                 Err(e) => {
                     *ret_code = CctpErrorCode::MerkleTreeError;
-                    log::error!("{:?}", format!("Error appending leaf: {:?}", e));
+                    log::error!("Error appending leaf: {:?}", e);
                     false
                 }
             }
@@ -1705,7 +1705,7 @@ pub extern "C" fn zendoo_append_leaf_to_ginger_mht_from_raw(
         // Deserialization failure
         Err(e) => {
             *ret_code = CctpErrorCode::InvalidBufferData;
-            log::error!("{:?}", format!("Error deserializing leaf: {:?}", e));
+            log::error!("Error deserializing leaf: {:?}", e);
             false
         }
     }
@@ -1723,7 +1723,7 @@ pub extern "C" fn zendoo_finalize_ginger_mht(
     match finalize_ginger_mht(tree) {
         Ok(tree_copy) => Box::into_raw(Box::new(tree_copy)),
         Err(e) => {
-            log::error!("{:?}", format!("Finalize merkle tree error: {:?}", e));
+            log::error!("Finalize merkle tree error: {:?}", e);
             *ret_code = CctpErrorCode::MerkleTreeError;
             null_mut()
         }
@@ -1741,7 +1741,7 @@ pub extern "C" fn zendoo_finalize_ginger_mht_in_place(
     match finalize_ginger_mht_in_place(tree) {
         Ok(_) => true,
         Err(e) => {
-            log::error!("{:?}", format!("Finalize merkle tree error: {:?}", e));
+            log::error!("Finalize merkle tree error: {:?}", e);
             *ret_code = CctpErrorCode::MerkleTreeError;
             false
         }
@@ -1761,7 +1761,7 @@ pub extern "C" fn zendoo_get_ginger_mht_root(
         Some(root) => Box::into_raw(Box::new(root)),
         None => {
             *ret_code = CctpErrorCode::MerkleRootBuildError;
-            log::error!("{:?}", "Error: tree not finalized");
+            log::error!("Error: tree not finalized");
             null_mut()
         }
     }
@@ -1781,7 +1781,7 @@ pub extern "C" fn zendoo_get_ginger_merkle_path(
         Some(path) => Box::into_raw(Box::new(path)),
         None => {
             *ret_code = CctpErrorCode::MerkleTreeError;
-            log::error!("{:?}", "Error: tree not finalized");
+            log::error!("Error: tree not finalized");
             null_mut()
         }
     }
@@ -1823,7 +1823,7 @@ pub extern "C" fn zendoo_verify_ginger_merkle_path(
         Ok(result) => result,
         Err(e) => {
             *ret_code = CctpErrorCode::MerkleTreeError;
-            log::error!("{:?}", format!("Error verifying merkle path: {:?}", e));
+            log::error!("Error verifying merkle path: {:?}", e);
             false
         }
     }
@@ -2143,7 +2143,7 @@ fn _zendoo_generate_mc_test_params(
             true
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error generating test params: {:?}", e));
+            log::error!("Error generating test params: {:?}", e);
             *ret_code = CctpErrorCode::GenericError;
             false
         }
@@ -2400,7 +2400,7 @@ pub extern "C" fn zendoo_create_cert_test_proof(
             true
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             false
         }
@@ -2472,7 +2472,7 @@ pub extern "C" fn zendoo_create_cert_test_proof(
             true
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             false
         }
@@ -2624,7 +2624,7 @@ pub extern "C" fn zendoo_create_csw_test_proof(
             true
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             false
         }
@@ -2686,7 +2686,7 @@ pub extern "C" fn zendoo_create_csw_test_proof(
             true
         }
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             false
         }
@@ -2744,13 +2744,13 @@ pub extern "C" fn zendoo_create_return_cert_test_proof(
                 Box::into_raw(Box::new(BufferWithSize { data, len }))
             }
             Err(e) => {
-                log::error!("{:?}", format!("Error serializing proof {:?}", e));
+                log::error!("Error serializing proof {:?}", e);
                 *ret_code = CctpErrorCode::InvalidValue;
                 null_mut()
             }
         },
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             null_mut()
         }
@@ -2798,13 +2798,13 @@ pub extern "C" fn zendoo_create_return_csw_test_proof(
                 Box::into_raw(Box::new(BufferWithSize { data, len }))
             }
             Err(e) => {
-                log::error!("{:?}", format!("Error serializing proof {:?}", e));
+                log::error!("Error serializing proof {:?}", e);
                 *ret_code = CctpErrorCode::InvalidValue;
                 null_mut()
             }
         },
         Err(e) => {
-            log::error!("{:?}", format!("Error creating proof {:?}", e));
+            log::error!("Error creating proof {:?}", e);
             *ret_code = CctpErrorCode::TestProofCreationFailure;
             null_mut()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,6 +1389,8 @@ pub extern "C" fn zendoo_batch_verify_all_proofs(
     let rs_batch_verifier =
         try_read_raw_pointer!("batch_verifier", batch_verifier, ret_code, null_mut());
 
+    log::info!("Begin batch verification of {} proofs...", rs_batch_verifier.num_proofs());
+
     // If prioritize, pause all low priority threads
     if prioritize {
         zendoo_pause_low_priority_threads();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,19 +36,16 @@ pub struct BufferWithSize {
 /// Check that `buffer` it's a valid buffer with non-zero data
 pub(crate) fn check_buffer(buffer: *const BufferWithSize) -> (bool, CctpErrorCode) {
     if buffer.is_null() {
-        //log::error!("===> ERR CODE {:?}", CctpErrorCode::NullPtr);
         return (false, CctpErrorCode::NullPtr);
     }
 
     let data_attr = unsafe { (*buffer).data };
     if data_attr.is_null() {
-        //log::error!("===> ERR CODE {:?}", CctpErrorCode::InvalidBufferData);
         return (false, CctpErrorCode::InvalidBufferData);
     }
 
     let len_attr = unsafe { (*buffer).len };
     if len_attr == 0 {
-        //log::error!("===> ERR CODE {:?}", CctpErrorCode::InvalidBufferLength);
         return (false, CctpErrorCode::InvalidBufferLength);
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,29 +4,6 @@ use cctp_primitives::utils::serialization::{
 };
 use std::{path::Path, slice};
 
-#[allow(unused_macros)]
-macro_rules! log {
-    ($msg: expr) => {{
-        log::error!("[{}:{}] {:?}", file!(), line!(), $msg)
-    }};
-}
-
-#[allow(unused_macros)]
-#[cfg(debug_assertions)]
-macro_rules! log_dbg {
-    ($msg: expr) => {{
-        log::error!("[{}:{}] {:?}", file!(), line!(), $msg)
-    }};
-}
-
-#[allow(unused_macros)]
-#[cfg(not(debug_assertions))]
-macro_rules! log_dbg {
-    ($msg: expr) => {{
-        ()
-    }};
-}
-
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 pub enum CctpErrorCode {

--- a/src/mc_test_circuits/csw.rs
+++ b/src/mc_test_circuits/csw.rs
@@ -248,9 +248,7 @@ pub fn generate_proof(
         ZendooProverKey::Darlin(pk) => {
             let ck_g2 = get_g2_committer_key(supported_degree)?;
             let deferred = FinalDarlinDeferredData::<G1, G2>::generate_random::<_, Digest>(
-                rng,
-                &ck_g1,
-                &ck_g2,
+                rng, &ck_g1, &ck_g2,
             );
             let deferred_fes = deferred.to_field_elements().unwrap();
             let circ = CSWTestCircuitWithAccumulators {
@@ -264,14 +262,9 @@ pub fn generate_proof(
                 deferred: deferred_fes.clone(),
                 num_constraints,
             };
-            let proof = CoboundaryMarlin::prove(
-                pk,
-                &ck_g1,
-                circ,
-                zk,
-                if zk { Some(rng) } else { None },
-            )
-            .map_err(|e| ProvingSystemError::ProofCreationFailed(e.to_string()))?;
+            let proof =
+                CoboundaryMarlin::prove(pk, &ck_g1, circ, zk, if zk { Some(rng) } else { None })
+                    .map_err(|e| ProvingSystemError::ProofCreationFailed(e.to_string()))?;
             let darlin_proof = FinalDarlinProof::<G1, G2, Digest> {
                 proof: MarlinProof(proof),
                 deferred,
@@ -289,14 +282,9 @@ pub fn generate_proof(
                 aggregated_input: Some(aggregated_input),
                 num_constraints,
             };
-            let proof = CoboundaryMarlin::prove(
-                pk,
-                &ck_g1,
-                circ,
-                zk,
-                if zk { Some(rng) } else { None },
-            )
-            .map_err(|e| ProvingSystemError::ProofCreationFailed(e.to_string()))?;
+            let proof =
+                CoboundaryMarlin::prove(pk, &ck_g1, circ, zk, if zk { Some(rng) } else { None })
+                    .map_err(|e| ProvingSystemError::ProofCreationFailed(e.to_string()))?;
             Ok(ZendooProof::CoboundaryMarlin(MarlinProof(proof)))
         }
     }

--- a/src/tests/log/sample_log_config.yaml
+++ b/src/tests/log/sample_log_config.yaml
@@ -1,0 +1,21 @@
+appenders:
+
+  file:
+    kind: rolling_file
+    path: test_log.log
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S)} | {({l}):5.5} | {f}:{L} — {m}{n}"
+    policy:
+      trigger:
+        kind: size
+        limit: 10 kb
+      roller:
+        kind: fixed_window
+        pattern: test_log_{}.gz
+        count: 5
+        base: 1
+
+root:
+  level: info
+  appenders:
+    - file

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -67,6 +67,7 @@ pub fn init_test_logger() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn init_logger_multiple() {
+    init_test_logger();
     let config_path = parse_path(LOG_CONFIG_PATH.as_ptr(), LOG_CONFIG_PATH.len());
     assert!(init_logger(config_path).is_err());
 }
@@ -74,6 +75,8 @@ fn init_logger_multiple() {
 #[cfg(target_os = "windows")]
 #[test]
 fn init_logger_multiple() {
+    init_test_logger();
+    
     // Read config file path
     let path_str = OsString::from_wide(unsafe {
         slice::from_raw_parts(LOG_CONFIG_PATH, LOG_CONFIG_PATH.len())

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
+    init_logger,
     macros::{BufferWithSize, CctpErrorCode},
-    zendoo_compress_bit_vector, zendoo_decompress_bit_vector, zendoo_free_bws, init_logger, parse_path,
+    parse_path, zendoo_compress_bit_vector, zendoo_decompress_bit_vector, zendoo_free_bws,
 };
 use cctp_primitives::bit_vector::compression::CompressionAlgorithm;
 use std::slice;
@@ -12,8 +13,8 @@ use crate::{
     zendoo_create_return_csw_test_proof, zendoo_deserialize_sc_pk_from_file,
     zendoo_deserialize_sc_proof, zendoo_deserialize_sc_vk_from_file, zendoo_field_free,
     zendoo_free_batch_proof_verifier_result, zendoo_generate_mc_test_params,
-    zendoo_get_random_field, zendoo_init_dlog_keys, zendoo_sc_pk_free, zendoo_sc_proof_free,
-    zendoo_sc_vk_free, zendoo_verify_certificate_proof, TestCircuitType, zendoo_init
+    zendoo_get_random_field, zendoo_init, zendoo_init_dlog_keys, zendoo_sc_pk_free,
+    zendoo_sc_proof_free, zendoo_sc_vk_free, zendoo_verify_certificate_proof, TestCircuitType,
 };
 
 #[cfg(feature = "mc-test-circuit")]
@@ -54,7 +55,11 @@ static INIT: Once = Once::new();
 pub fn init_test_logger() {
     INIT.call_once(|| {
         let mut ret_code = CctpErrorCode::OK;
-        zendoo_init(path_as_ptr(LOG_CONFIG_PATH), LOG_CONFIG_PATH.len(), &mut ret_code);
+        zendoo_init(
+            path_as_ptr(LOG_CONFIG_PATH),
+            LOG_CONFIG_PATH.len(),
+            &mut ret_code,
+        );
         assert_eq!(ret_code, CctpErrorCode::OK);
     });
 }
@@ -69,11 +74,12 @@ fn init_logger_multiple() {
 #[cfg(target_os = "windows")]
 #[test]
 fn init_logger_multiple() {
-
     // Read config file path
-    let path_str = OsString::from_wide(unsafe { slice::from_raw_parts(LOG_CONFIG_PATH, LOG_CONFIG_PATH.len())});
+    let path_str = OsString::from_wide(unsafe {
+        slice::from_raw_parts(LOG_CONFIG_PATH, LOG_CONFIG_PATH.len())
+    });
     let config_path = Path::new(&path_str);
-    
+
     assert!(init_logger(config_path).is_err());
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -36,12 +36,12 @@ use std::ffi::OsString;
 #[cfg(target_os = "windows")]
 use std::os::windows::ffi::OsStrExt;
 
-#[cfg(all(feature = "mc-test-circuit", not(target_os = "windows")))]
+#[cfg(not(target_os = "windows"))]
 fn path_as_ptr(path: &str) -> *const u8 {
     path.as_ptr()
 }
 
-#[cfg(all(feature = "mc-test-circuit", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 fn path_as_ptr(path: &str) -> *const u16 {
     let tmp: Vec<u16> = OsString::from(path).encode_wide().collect();
     tmp.as_ptr()
@@ -104,14 +104,14 @@ fn serialization_deserialization_bench_vk_proof() {
     init_test_logger();
 
     // Init DLOG keys
-    log::info!("Setup DLOG keys...");
+    println!("Setup DLOG keys...");
     assert!(zendoo_init_dlog_keys(segment_size, &mut CctpErrorCode::OK));
 
     // CSW
-    log::info!("Bench serialize/deserialize CSW...");
+    println!("Bench serialize/deserialize CSW...");
     {
         // Generate SNARK keys
-        log::info!("Generate SNARK pk and vk...");
+        println!("Generate SNARK pk and vk...");
         let (pk, vk) = crate::mc_test_circuits::csw::generate_parameters(
             ProvingSystem::Darlin,
             num_constraints,
@@ -120,7 +120,7 @@ fn serialization_deserialization_bench_vk_proof() {
         )
         .unwrap();
 
-        log::info!("Generate proof...");
+        println!("Generate proof...");
         let proof = crate::mc_test_circuits::csw::generate_proof(
             &pk,
             true,
@@ -136,7 +136,7 @@ fn serialization_deserialization_bench_vk_proof() {
         )
         .unwrap();
 
-        log::info!("Test deserialization...");
+        println!("Test deserialization...");
         for compressed in vec![true, false].into_iter() {
             // Serialize vk and proof in compressed/uncompressed form
             let mut vk_bytes = serialize_to_buffer(&vk, Some(compressed)).unwrap();
@@ -153,13 +153,13 @@ fn serialization_deserialization_bench_vk_proof() {
 
             // Deserialize with various combinations
             for semantic_checks in vec![true, false].into_iter() {
-                log::info!(
+                println!(
                     "Compressed: {}, Semantic checks: {}",
                     compressed,
                     semantic_checks
                 );
-                log::info!("Vk len: {}", len_vk);
-                log::info!("Proof len: {}", len_proof);
+                println!("Vk len: {}", len_vk);
+                println!("Proof len: {}", len_proof);
 
                 let total_deser_vk_time = std::time::Instant::now();
                 for _ in 0..num_proofs {
@@ -171,7 +171,7 @@ fn serialization_deserialization_bench_vk_proof() {
                     );
                     assert!(vk != null_mut());
                 }
-                log::info!(
+                println!(
                     "Total time to deserialize {} vks: {:?}",
                     num_proofs,
                     total_deser_vk_time.elapsed()
@@ -187,7 +187,7 @@ fn serialization_deserialization_bench_vk_proof() {
                     );
                     assert!(proof != null_mut());
                 }
-                log::info!(
+                println!(
                     "Total time to deserialize {} proofs: {:?}",
                     num_proofs,
                     total_deser_proof_time.elapsed()
@@ -199,12 +199,12 @@ fn serialization_deserialization_bench_vk_proof() {
     }
 
     // CERT
-    log::info!("Bench serialize/deserialize CERT...");
+    println!("Bench serialize/deserialize CERT...");
     {
         let num_constraints = num_constraints * 2;
 
         // Generate SNARK keys
-        log::info!("Generate SNARK pk and vk...");
+        println!("Generate SNARK pk and vk...");
         let (pk, vk) = crate::mc_test_circuits::cert::generate_parameters(
             ProvingSystem::Darlin,
             num_constraints,
@@ -214,7 +214,7 @@ fn serialization_deserialization_bench_vk_proof() {
         )
         .unwrap();
 
-        log::info!("Generate proof...");
+        println!("Generate proof...");
         let proof = crate::mc_test_circuits::cert::generate_proof(
             &pk,
             true,
@@ -233,7 +233,7 @@ fn serialization_deserialization_bench_vk_proof() {
         )
         .unwrap();
 
-        log::info!("Test deserialization...");
+        println!("Test deserialization...");
         for compressed in vec![true, false].into_iter() {
             // Serialize vk and proof in compressed/uncompressed form
             let mut vk_bytes = serialize_to_buffer(&vk, Some(compressed)).unwrap();
@@ -250,13 +250,13 @@ fn serialization_deserialization_bench_vk_proof() {
 
             // Deserialize with various combinations
             for semantic_checks in vec![true, false].into_iter() {
-                log::info!(
+                println!(
                     "Compressed: {}, Semantic checks: {}",
                     compressed,
                     semantic_checks
                 );
-                log::info!("Vk len: {}", len_vk);
-                log::info!("Proof len: {}", len_proof);
+                println!("Vk len: {}", len_vk);
+                println!("Proof len: {}", len_proof);
 
                 let total_deser_vk_time = std::time::Instant::now();
                 for _ in 0..num_proofs {
@@ -268,7 +268,7 @@ fn serialization_deserialization_bench_vk_proof() {
                     );
                     assert!(vk != null_mut());
                 }
-                log::info!(
+                println!(
                     "Total time to deserialize {} vks: {:?}",
                     num_proofs,
                     total_deser_vk_time.elapsed()
@@ -284,7 +284,7 @@ fn serialization_deserialization_bench_vk_proof() {
                     );
                     assert!(proof != null_mut());
                 }
-                log::info!(
+                println!(
                     "Total time to deserialize {} proofs: {:?}",
                     num_proofs,
                     total_deser_proof_time.elapsed()
@@ -303,12 +303,12 @@ fn prev_sc_cert_hash_support() {
     init_test_logger();
 
     // Init DLOG keys
-    log::info!("Setup DLOG keys...");
+    println!("Setup DLOG keys...");
     assert!(zendoo_init_dlog_keys(segment_size, &mut CctpErrorCode::OK));
 
     let num_constraints = 1 << 16;
 
-    log::info!(
+    println!(
         "Generating cert proof with {} constraints...",
         num_constraints
     );
@@ -316,7 +316,7 @@ fn prev_sc_cert_hash_support() {
     std::fs::create_dir_all("./src/tests/keyrot").unwrap();
 
     // Generate SNARK keys
-    log::info!("Generate SNARK pk and vk...");
+    println!("Generate SNARK pk and vk...");
     assert!(zendoo_generate_mc_test_params(
         TestCircuitType::Certificate,
         ProvingSystem::Darlin,
@@ -349,7 +349,7 @@ fn prev_sc_cert_hash_support() {
     );
     assert!(pk != null_mut());
 
-    log::info!("Generate proof...");
+    println!("Generate proof...");
     let random_field_proof = zendoo_get_random_field();
     let proof_buff = zendoo_create_return_cert_test_proof(
         true,
@@ -385,7 +385,7 @@ fn prev_sc_cert_hash_support() {
     );
     assert!(vk != null_mut());
 
-    log::info!("Verifying proof...");
+    println!("Verifying proof...");
     assert!(zendoo_verify_certificate_proof(
         constant,
         sc_id,
@@ -404,7 +404,7 @@ fn prev_sc_cert_hash_support() {
         &mut CctpErrorCode::OK
     ));
 
-    log::info!("Assert failure with wrong key...");
+    println!("Assert failure with wrong key...");
     let random_field_wrong = zendoo_get_random_field();
     assert!(!zendoo_verify_certificate_proof(
         constant,
@@ -425,7 +425,7 @@ fn prev_sc_cert_hash_support() {
     ));
 
     // Free memory
-    log::info!("Cleaning up...");
+    println!("Cleaning up...");
     zendoo_field_free(constant);
     zendoo_field_free(sc_id);
     zendoo_field_free(end_cum_comm_tree_root);
@@ -436,7 +436,7 @@ fn prev_sc_cert_hash_support() {
     zendoo_field_free(random_field_proof);
     zendoo_field_free(random_field_wrong);
 
-    log::info!("Cleaning up...");
+    println!("Cleaning up...");
     std::fs::remove_file("./src/tests/keyrot/darlin_cert_test_pk").unwrap();
     std::fs::remove_file("./src/tests/keyrot/darlin_cert_test_vk").unwrap();
     std::fs::remove_dir("./src/tests/keyrot").unwrap();
@@ -450,7 +450,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
 
     // Init DLOG keys
     init_test_logger();
-    log::info!("Setup DLOG keys...");
+    println!("Setup DLOG keys...");
     assert!(zendoo_init_dlog_keys(segment_size, &mut CctpErrorCode::OK));
 
     for j in 15..=16 {
@@ -461,14 +461,14 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
         {
             let num_constraints = 1 << (j + 1);
 
-            log::info!(
+            println!(
                 "Generating {} cert proofs with {} constraints...",
                 num_proofs / 2,
                 num_constraints
             );
 
             // Generate SNARK keys
-            log::info!("Generate SNARK pk and vk...");
+            println!("Generate SNARK pk and vk...");
             assert!(zendoo_generate_mc_test_params(
                 TestCircuitType::Certificate,
                 ProvingSystem::Darlin,
@@ -501,7 +501,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             );
             assert!(pk != null_mut());
 
-            log::info!("Generate proof...");
+            println!("Generate proof...");
             let proof_buff = zendoo_create_return_cert_test_proof(
                 true,
                 constant,
@@ -537,7 +537,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             );
             assert!(vk != null_mut());
 
-            log::info!("Add proofs to batch verifier...");
+            println!("Add proofs to batch verifier...");
             for i in 0..num_proofs / 2 {
                 assert!(zendoo_add_certificate_proof_to_batch_verifier(
                     &mut bv,
@@ -561,7 +561,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             }
 
             // Free memory
-            log::info!("Cleaning up...");
+            println!("Cleaning up...");
             zendoo_field_free(constant);
             zendoo_field_free(sc_id);
             zendoo_field_free(end_cum_comm_tree_root);
@@ -575,14 +575,14 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
         {
             let num_constraints = 1 << j;
 
-            log::info!(
+            println!(
                 "Generating {} CSW proofs with {} constraints...",
                 num_proofs / 2,
                 num_constraints
             );
 
             // Generate SNARK keys
-            log::info!("Generate SNARK pk and vk...");
+            println!("Generate SNARK pk and vk...");
             assert!(zendoo_generate_mc_test_params(
                 TestCircuitType::CSW,
                 ProvingSystem::Darlin,
@@ -627,7 +627,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             );
             assert!(pk != null_mut());
 
-            log::info!("Generate proof...");
+            println!("Generate proof...");
             let proof_buff = zendoo_create_return_csw_test_proof(
                 true,
                 0,
@@ -658,7 +658,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             );
             assert!(vk != null_mut());
 
-            log::info!("Add proofs to batch verifier...");
+            println!("Add proofs to batch verifier...");
             for i in num_proofs / 2..num_proofs {
                 assert!(zendoo_add_csw_proof_to_batch_verifier(
                     &mut bv,
@@ -677,7 +677,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
             }
 
             // Free memory
-            log::info!("Cleaning up...");
+            println!("Cleaning up...");
             zendoo_field_free(constant);
             zendoo_field_free(sc_id);
             zendoo_field_free(nullifier);
@@ -695,7 +695,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
         let rng = &mut thread_rng();
         let num_threads: usize = rng.gen_range(2..11);
 
-        log::info!(
+        println!(
             "Perform {} separate batch verifications with different priority...",
             num_threads
         );
@@ -720,7 +720,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
                 low_priority_timings.clone()
             };
             let handle = std::thread::spawn(move || {
-                log::info!("Thread {} started", i);
+                println!("Thread {} started", i);
 
                 // Execute batch verification and take the time
                 let start = std::time::Instant::now();
@@ -734,12 +734,12 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
                 }
                 zendoo_free_batch_proof_verifier_result(result);
 
-                log::info!("Thread {} finished in: {:?}", i, time);
+                println!("Thread {} finished in: {:?}", i, time);
 
                 // Push execution time in timings vec
                 timings_vec_ref.write().unwrap().push(time.as_millis());
             });
-            log::info!(
+            println!(
                 "Spawned batch verification thread {} with priority {}",
                 i,
                 priority
@@ -768,7 +768,7 @@ fn zendoo_batch_verifier_multiple_threads_with_priority() {
                     / low_priority_timings.clone().read().unwrap().len() as u128
         );
 
-        log::info!("Cleaning up...");
+        println!("Cleaning up...");
         std::fs::remove_file("./src/tests/darlin_cert_test_pk").unwrap();
         std::fs::remove_file("./src/tests/darlin_cert_test_vk").unwrap();
         std::fs::remove_file("./src/tests/darlin_csw_test_pk").unwrap();


### PR DESCRIPTION
Added log4rs support and a new `init_zendoo()` function to be called at node startup. The function is generic but currently it just initializes a logger with a configuration using a .yaml file supposed to be supplied by the caller.
Then, I basically replaced the `print!` and `println!` with `log::debug!` or `log::info!` (according to the situation) and the `eprint!` and `eprintln!` with `log::error!`